### PR TITLE
chore(gitattributes): ignore generated files for pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.g.dart linguist-generated
+*.freezed.dart linguist-generated
+*.mocks.dart linguist-generated
+*.look.dart linguist-generated
+*.lookgolden.dart linguist-generated
+*.lock linguist-generated


### PR DESCRIPTION
# Description
What are changes related to ?
Configure generated files as ignored for pull requests

# Linked Issues
What are the issues fixed by this pull request ?
None

# Changes
What does it change ?
Generated files won't be compared in pull requests anymore

Is is a breaking change ?
No

Is is a new feature ?
No

Is is a patch, fix, hotfix ?
Fix

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
