### PR TITLE
change allowed prefixes on ci

### DIFF
--- a/.github/workflows/git_checks.yaml
+++ b/.github/workflows/git_checks.yaml
@@ -11,7 +11,7 @@ jobs:
         if: github.base_ref == 'main'
         run: |
           echo "base ref is main checking branch name..."
-          ALLOWED_PREFIXES="feature feat fix hotfix release chore dependabot"
+          ALLOWED_PREFIXES="feature feat fix hotfix release chore dependabot docs test"
           BRANCH_NAME_VALID=false
           PREFIXES_ARRAY=$(echo $ALLOWED_PREFIXES | tr " " "\n")
           for PREFIX in $PREFIXES_ARRAY ; 


### PR DESCRIPTION
Add allowed prefix for the check branch name on CI because docs and test was missing 