### PR TITLE
refactor(httpResponse): remove api httpResponse type, changed reposit…

### DIFF
--- a/yaki_mobile/lib/data/models/team_mate_model.dart
+++ b/yaki_mobile/lib/data/models/team_mate_model.dart
@@ -10,19 +10,40 @@ class TeamMateModel {
   String userLastName;
   @JsonKey(name: 'user_first_name')
   String userFirstName;
+  @JsonKey(name: 'user_email')
+  String userEmail;
+  @JsonKey(name: 'user_login')
+  String userLogin;
+  @JsonKey(name: 'user_password')
+  String userPassword;
   @JsonKey(name: 'team_mate_id')
   int teamMateId;
+  @JsonKey(name: 'team_mate_team_id')
+  int teamMateTeamId;
+  @JsonKey(name: 'team_mate_user_id')
+  int teamMateUserId;
   @JsonKey(name: 'declaration_date')
-  DateTime? declarationDate;
+  DateTime declarationDate;
+  @JsonKey(name: 'declaration_team_mate_id')
+  int declarationTeamMateId;
+  @JsonKey(name: 'declaration_id')
+  int declarationId;
   @JsonKey(name: 'declaration_status')
-  String? declarationStatus;
+  String declarationStatus;
 
   TeamMateModel({
     required this.userId,
     required this.userLastName,
     required this.userFirstName,
+    required this.userEmail,
+    required this.userLogin,
+    required this.userPassword,
     required this.teamMateId,
+    required this.teamMateTeamId,
+    required this.teamMateUserId,
     required this.declarationDate,
+    required this.declarationTeamMateId,
+    required this.declarationId,
     required this.declarationStatus,
   });
 

--- a/yaki_mobile/lib/data/models/team_mate_model.g.dart
+++ b/yaki_mobile/lib/data/models/team_mate_model.g.dart
@@ -11,11 +11,16 @@ TeamMateModel _$TeamMateModelFromJson(Map<String, dynamic> json) =>
       userId: json['user_id'] as int,
       userLastName: json['user_last_name'] as String,
       userFirstName: json['user_first_name'] as String,
+      userEmail: json['user_email'] as String,
+      userLogin: json['user_login'] as String,
+      userPassword: json['user_password'] as String,
       teamMateId: json['team_mate_id'] as int,
-      declarationDate: json['declaration_date'] == null
-          ? null
-          : DateTime.parse(json['declaration_date'] as String),
-      declarationStatus: json['declaration_status'] as String?,
+      teamMateTeamId: json['team_mate_team_id'] as int,
+      teamMateUserId: json['team_mate_user_id'] as int,
+      declarationDate: DateTime.parse(json['declaration_date'] as String),
+      declarationTeamMateId: json['declaration_team_mate_id'] as int,
+      declarationId: json['declaration_id'] as int,
+      declarationStatus: json['declaration_status'] as String,
     );
 
 Map<String, dynamic> _$TeamMateModelToJson(TeamMateModel instance) =>
@@ -23,7 +28,14 @@ Map<String, dynamic> _$TeamMateModelToJson(TeamMateModel instance) =>
       'user_id': instance.userId,
       'user_last_name': instance.userLastName,
       'user_first_name': instance.userFirstName,
+      'user_email': instance.userEmail,
+      'user_login': instance.userLogin,
+      'user_password': instance.userPassword,
       'team_mate_id': instance.teamMateId,
-      'declaration_date': instance.declarationDate?.toIso8601String(),
+      'team_mate_team_id': instance.teamMateTeamId,
+      'team_mate_user_id': instance.teamMateUserId,
+      'declaration_date': instance.declarationDate.toIso8601String(),
+      'declaration_team_mate_id': instance.declarationTeamMateId,
+      'declaration_id': instance.declarationId,
       'declaration_status': instance.declarationStatus,
     };

--- a/yaki_mobile/lib/data/models/user.dart
+++ b/yaki_mobile/lib/data/models/user.dart
@@ -5,8 +5,10 @@ part 'user.g.dart';
 @JsonSerializable()
 class User {
   int? captainId;
+
   int? teamMateId;
   int? teamId;
+
   int? userId;
   String? lastName;
   String? firstName;

--- a/yaki_mobile/lib/data/repositories/login_repository.dart
+++ b/yaki_mobile/lib/data/repositories/login_repository.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:retrofit/retrofit.dart';
 import 'package:yaki/data/models/user.dart';
 import 'package:yaki/data/sources/local/shared_preference.dart';
 import 'package:yaki/data/sources/remote/login_api.dart';
@@ -10,39 +9,30 @@ import 'package:crypt/crypt.dart';
 class LoginRepository {
   final LoginApi _loginApi;
   LoggedUser? loggedUser;
+  // isCaptain determine redirection after login.
+  bool? isCaptain = false;
 
-  LoginRepository(this._loginApi);
+  LoginRepository(
+    this._loginApi, {
+    this.loggedUser,
+    this.isCaptain,
+  });
 
   Future<bool> userAuthentication(String login, String password) async {
     Login newLog = Login(login: login, password: password);
-
-    final authenticationResponse = await _loginApi.postLogin(newLog);
-    bool isCaptain = handleResponse(authenticationResponse);
-
-    return isCaptain;
-  }
-
-  bool handleResponse(HttpResponse<User?> response) {
-    bool isCaptain = false;
     try {
-      final statusCode = response.response.statusCode;
+      final authenticationResponse = await _loginApi.postLogin(newLog);
+      // convert HttpResponse<dynamic> (Map<String, dynamic>) into Model using .fromJson method
+      final userResponse = User.fromJson(authenticationResponse.data);
 
+      final statusCode = authenticationResponse.response.statusCode;
       switch (statusCode) {
         case 200:
-          final data = response.data!;
-          addTokenToSharedPreference(data.token);
-          addUserIdToSharedPreference(data.userId);
-          loggedUser = LoggedUser(
-            teamMateid: data.teamMateId,
-            lastName: data.lastName,
-            firstName: data.firstName,
-            email: data.email,
-          );
-
-          if (response.data?.captainId != null) {
+          setSharedPreference(userResponse);
+          setLoggedUser(userResponse);
+          if (userResponse.captainId != null) {
             isCaptain = true;
           }
-
           break;
         case 204:
           debugPrint("invalid login informations, code : $statusCode");
@@ -51,13 +41,30 @@ class LoginRepository {
           debugPrint("Invalid token, code : $statusCode");
           break;
         default:
-          throw Exception(response.response.statusMessage);
+          throw Exception(authenticationResponse.response.statusMessage);
       }
     } catch (err) {
       debugPrint('login exception : $err');
     }
+    return isCaptain!;
+  }
 
-    return isCaptain;
+  /// Attributes from User model,
+  /// to be saved into sharedPreferences.
+  void setSharedPreference(User user) {
+    addTokenToSharedPreference(user.token);
+    addUserIdToSharedPreference(user.userId);
+  }
+
+  /// Retrieve User model attributes
+  /// and assign the selected attributes to the loggedUser entities
+  void setLoggedUser(User user) {
+    loggedUser = LoggedUser(
+      teamMateid: user.teamMateId ?? 0,
+      lastName: user.lastName ?? "",
+      firstName: user.firstName ?? "",
+      email: user.email ?? "",
+    );
   }
 
   /// hash password received from authentication page
@@ -68,7 +75,6 @@ class LoginRepository {
       rounds: 10000,
       salt: const String.fromEnvironment('CRED_HASH_PASS'),
     );
-
     return hashPass.toString();
   }
 

--- a/yaki_mobile/lib/data/repositories/team_mate_repository.dart
+++ b/yaki_mobile/lib/data/repositories/team_mate_repository.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:yaki/data/sources/team_mate_api.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:yaki/data/models/team_mate_model.dart';
+import 'package:yaki/data/sources/remote/team_mate_api.dart';
 import 'package:yaki/domain/entities/team_mate_entity.dart';
 
 class TeamMateRepository {
@@ -14,19 +16,36 @@ class TeamMateRepository {
 
   Future<List<TeamMateEntity>> getTeamMate() async {
     try {
-      final listTeamMateModel = await teamMateApi.getTeamMate();
-      teamMatelist = listTeamMateModel.map((e) {
-        return TeamMateEntity(
-          userFirstName: e.userFirstName,
-          userLastName: e.userLastName,
-          declarationDate: e.declarationDate,
-          declarationStatus: e.declarationStatus,
-        );
-      }).toList();
+      final listHttpResponse = await teamMateApi.getTeamMate();
+      final modelList = setTeamMateModelList(listHttpResponse);
+
+      teamMatelist = modelList.map(
+        (e) {
+          return TeamMateEntity(
+            userFirstName: e.userFirstName,
+            userLastName: e.userLastName,
+            declarationDate: e.declarationDate,
+            declarationStatus: e.declarationStatus,
+          );
+        },
+      ).toList();
       return teamMatelist;
     } catch (e) {
       debugPrint('erreur dans le repo : $e');
       return [];
     }
+  }
+
+  /// Function converting httpResponse.data ( a List<dynamic> of Map ) into a
+  /// List<TeamMateModel> using map, which create a List<dynamic> of TeamMateModel.
+  /// Convert it afterward into a List<TeamMateModel>
+  List<TeamMateModel> setTeamMateModelList(HttpResponse response) {
+    final dynamicList = response.data.map(
+      (teammate) {
+        return TeamMateModel.fromJson(teammate);
+      },
+    ).toList();
+    List<TeamMateModel> modelList = List<TeamMateModel>.from(dynamicList);
+    return modelList;
   }
 }

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:yaki/data/models/declaration_model.dart';
-import 'package:yaki/data/models/declaration_model_in.dart';
 
 part 'declaration_api.g.dart';
 
@@ -10,12 +9,12 @@ abstract class DeclarationApi {
   factory DeclarationApi(Dio dio, {required String baseUrl}) = _DeclarationApi;
 
   @GET('/declarations')
-  Future<HttpResponse<DeclarationModelIn?>> getDeclaration(
+  Future<HttpResponse> getDeclaration(
     @Query("teamMateId") String id,
   );
 
   @POST('/declarations')
-  Future<HttpResponse<DeclarationModelIn>> create(
+  Future<HttpResponse> create(
     @Body() DeclarationModel declaration,
   );
 }

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
@@ -19,40 +19,38 @@ class _DeclarationApi implements DeclarationApi {
   String? baseUrl;
 
   @override
-  Future<HttpResponse<DeclarationModelIn?>> getDeclaration(id) async {
+  Future<HttpResponse<dynamic>> getDeclaration(id) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{r'teamMateId': id};
     final _headers = <String, dynamic>{};
     final Map<String, dynamic>? _data = null;
-    final _result = await _dio.fetch<Map<String, dynamic>?>(
-        _setStreamType<HttpResponse<DeclarationModelIn>>(Options(
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
       method: 'GET',
       headers: _headers,
       extra: _extra,
     )
             .compose(
               _dio.options,
-              '/declarations/',
+              '/declarations',
               queryParameters: queryParameters,
               data: _data,
             )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    final value = _result.data == null
-        ? null
-        : DeclarationModelIn.fromJson(_result.data!);
+    final value = _result.data;
     final httpResponse = HttpResponse(value, _result);
     return httpResponse;
   }
 
   @override
-  Future<HttpResponse<DeclarationModelIn>> create(declaration) async {
+  Future<HttpResponse<dynamic>> create(declaration) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(declaration.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<HttpResponse<DeclarationModelIn>>(Options(
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
       method: 'POST',
       headers: _headers,
       extra: _extra,
@@ -64,7 +62,7 @@ class _DeclarationApi implements DeclarationApi {
               data: _data,
             )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    final value = DeclarationModelIn.fromJson(_result.data!);
+    final value = _result.data;
     final httpResponse = HttpResponse(value, _result);
     return httpResponse;
   }

--- a/yaki_mobile/lib/data/sources/remote/login_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/login_api.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:yaki/data/models/login.dart';
-import 'package:yaki/data/models/user.dart';
 
 part 'login_api.g.dart';
 
@@ -10,5 +9,5 @@ abstract class LoginApi {
   factory LoginApi(Dio dio, {required String baseUrl}) = _LoginApi;
 
   @POST('/login')
-  Future<HttpResponse<User?>> postLogin(@Body() Login login);
+  Future<HttpResponse> postLogin(@Body() Login login);
 }

--- a/yaki_mobile/lib/data/sources/remote/login_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/login_api.g.dart
@@ -19,14 +19,14 @@ class _LoginApi implements LoginApi {
   String? baseUrl;
 
   @override
-  Future<HttpResponse<User?>> postLogin(login) async {
+  Future<HttpResponse<dynamic>> postLogin(login) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(login.toJson());
-    final _result = await _dio.fetch<Map<String, dynamic>?>(
-        _setStreamType<HttpResponse<User>>(Options(
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
       method: 'POST',
       headers: _headers,
       extra: _extra,
@@ -38,7 +38,7 @@ class _LoginApi implements LoginApi {
               data: _data,
             )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    final value = _result.data == null ? null : User.fromJson(_result.data!);
+    final value = _result.data;
     final httpResponse = HttpResponse(value, _result);
     return httpResponse;
   }

--- a/yaki_mobile/lib/data/sources/remote/team_mate_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/team_mate_api.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
-import 'package:yaki/data/models/team_mate_model.dart';
 
 part 'team_mate_api.g.dart';
 
@@ -9,5 +8,5 @@ abstract class TeamMateApi {
   factory TeamMateApi(Dio dio, {required String baseUrl}) = _TeamMateApi;
 
   @GET('/teamMates')
-  Future<List<TeamMateModel>> getTeamMate();
+  Future<HttpResponse> getTeamMate();
 }

--- a/yaki_mobile/lib/data/sources/remote/team_mate_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/team_mate_api.g.dart
@@ -19,13 +19,13 @@ class _TeamMateApi implements TeamMateApi {
   String? baseUrl;
 
   @override
-  Future<List<TeamMateModel>> getTeamMate() async {
+  Future<HttpResponse<dynamic>> getTeamMate() async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final Map<String, dynamic>? _data = null;
-    final _result = await _dio
-        .fetch<List<dynamic>>(_setStreamType<List<TeamMateModel>>(Options(
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
       method: 'GET',
       headers: _headers,
       extra: _extra,
@@ -37,10 +37,9 @@ class _TeamMateApi implements TeamMateApi {
               data: _data,
             )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    var value = _result.data!
-        .map((dynamic i) => TeamMateModel.fromJson(i as Map<String, dynamic>))
-        .toList();
-    return value;
+    final value = _result.data;
+    final httpResponse = HttpResponse(value, _result);
+    return httpResponse;
   }
 
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {

--- a/yaki_mobile/lib/domain/entities/team_mate_entity.dart
+++ b/yaki_mobile/lib/domain/entities/team_mate_entity.dart
@@ -1,8 +1,8 @@
 class TeamMateEntity {
   String userFirstName;
   String userLastName;
-  DateTime? declarationDate;
-  String? declarationStatus;
+  DateTime declarationDate;
+  String declarationStatus;
 
   TeamMateEntity({
     required this.userFirstName,

--- a/yaki_mobile/lib/presentation/state/providers/team_mate_provider.dart
+++ b/yaki_mobile/lib/presentation/state/providers/team_mate_provider.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaki/data/repositories/team_mate_repository.dart';
-import 'package:yaki/data/sources/team_mate_api.dart';
+import 'package:yaki/data/sources/remote/team_mate_api.dart';
 import 'package:yaki/domain/entities/team_mate_entity.dart';
 import 'package:yaki/presentation/state/notifiers/team_mate_notifier.dart';
 

--- a/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card.dart
+++ b/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card.dart
@@ -17,8 +17,8 @@ class CardTeamMate extends StatefulWidget {
 
   final String firstName;
   final String lastName;
-  final String? status;
-  final DateTime? dateActu;
+  final String status;
+  final DateTime dateActu;
 
   @override
   State<CardTeamMate> createState() => _CardTeamMateState();
@@ -31,8 +31,7 @@ class _CardTeamMateState extends State<CardTeamMate> {
     var size = MediaQuery.of(context).size;
 
     // Format Date.nom
-    // var dateDec = DateFormat('dd/MM/yyyy HH:mm')
-    //     .format(widget.dateActu ?? DateTime.now());
+    var dateDec = DateFormat('dd/MM/yyyy HH:mm').format(widget.dateActu);
 
     return Card(
       child: Column(
@@ -102,10 +101,7 @@ class _CardTeamMateState extends State<CardTeamMate> {
                         alignment: Alignment.bottomLeft,
                         child: Text(
                           // Actualisation Date
-                          widget.dateActu != null
-                              ? DateFormat('dd/MM/yyyy HH:mm')
-                                  .format(widget.dateActu!)
-                              : '',
+                          dateDec,
                           style: const TextStyle(
                             fontWeight: FontWeight.bold,
                           ),
@@ -115,7 +111,7 @@ class _CardTeamMateState extends State<CardTeamMate> {
                         width: size.width * 0.60,
                         child: Text(
                           // Status of the Team Mate
-                          widget.status ?? 'Undeclared',
+                          widget.status,
                           textAlign: TextAlign.end,
                           style: const TextStyle(
                             fontSize: 30,

--- a/yaki_mobile/pubspec.lock
+++ b/yaki_mobile/pubspec.lock
@@ -189,7 +189,7 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "2644a9e0965a7aa3deb09cb8ce4081db4450c178f472818c8cd34216a3070d7b"
+      sha256: "3e5c4a94d112540d0c9a6b7f3969832e1604eb8cde0f88d0808382f9f632100b"
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
@@ -271,7 +271,7 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "017cb37b3e9bee44cc800e35469f295d537484602f02ce6ceb5876236cc7e1fe"
+      sha256: "12006889e2987c549c4c1ec1a5ba4ec4b24d34d2469ee5f9476c926dcecff266"
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
@@ -774,7 +774,7 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "2f317d969a9f1eb59d1890643107da749698b7c08c4b0532fc95c8a7130d2803"
+      sha256: "4cf8e60dbe4d3a693d37dff11255a172594c0793da542183cbfe7fe978ae4aaa"
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
@@ -782,7 +782,7 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "13cccfda2dd61232a19dfb769b7a907e2ab23aabfebb9053c81e29c6c11b1766"
+      sha256: "278ad5f816f58b1967396d1f78ced470e3e58c9fe4b27010102c0a595c764468"
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
@@ -790,7 +790,7 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "524c9889a1327401124fe068840a8867f0d57987c1219a2a696ade629ec2bec3"
+      sha256: "0bf61ad56e6fd6688a2865d3ceaea396bc6a0a90ea0d7ad5049b1b76c09d6163"
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"

--- a/yaki_mobile/test/widget_test.mocks.dart
+++ b/yaki_mobile/test/widget_test.mocks.dart
@@ -7,8 +7,7 @@ import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:retrofit/retrofit.dart' as _i2;
-import 'package:yaki/data/models/declaration_model.dart' as _i6;
-import 'package:yaki/data/models/declaration_model_in.dart' as _i5;
+import 'package:yaki/data/models/declaration_model.dart' as _i5;
 import 'package:yaki/data/sources/remote/declaration_api.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -42,38 +41,36 @@ class MockDeclarationApi extends _i1.Mock implements _i3.DeclarationApi {
   }
 
   @override
-  _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn?>> getDeclaration(
-          String? id) =>
+  _i4.Future<_i2.HttpResponse<dynamic>> getDeclaration(String? id) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDeclaration,
           [id],
         ),
-        returnValue:
-            _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn?>>.value(
-                _FakeHttpResponse_0<_i5.DeclarationModelIn?>(
+        returnValue: _i4.Future<_i2.HttpResponse<dynamic>>.value(
+            _FakeHttpResponse_0<dynamic>(
           this,
           Invocation.method(
             #getDeclaration,
             [id],
           ),
         )),
-      ) as _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn?>>);
+      ) as _i4.Future<_i2.HttpResponse<dynamic>>);
   @override
-  _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn>> create(
-          _i6.DeclarationModel? declaration) =>
+  _i4.Future<_i2.HttpResponse<dynamic>> create(
+          _i5.DeclarationModel? declaration) =>
       (super.noSuchMethod(
         Invocation.method(
           #create,
           [declaration],
         ),
-        returnValue: _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn>>.value(
-            _FakeHttpResponse_0<_i5.DeclarationModelIn>(
+        returnValue: _i4.Future<_i2.HttpResponse<dynamic>>.value(
+            _FakeHttpResponse_0<dynamic>(
           this,
           Invocation.method(
             #create,
             [declaration],
           ),
         )),
-      ) as _i4.Future<_i2.HttpResponse<_i5.DeclarationModelIn>>);
+      ) as _i4.Future<_i2.HttpResponse<dynamic>>);
 }


### PR DESCRIPTION
# Description
Remove type from API response HttpResponse<T> object. Which will allow more convenient unit  testing.
Refactored  respositories to reflect this change.
Additionnal  login and declaration repo refactor.

# Linked Issues
N/A

# Changes
What does it change ? refactoring
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
N/A

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
N/A
