### PR TITLE
fix(declaration): add constraints to declaration table in database

### DIFF
--- a/yaki_backend/src/db/create_tables.sql
+++ b/yaki_backend/src/db/create_tables.sql
@@ -175,7 +175,7 @@ CREATE TABLE IF NOT EXISTS public.declaration
 (
     declaration_id integer NOT NULL DEFAULT nextval('declaration_id_seq'::regclass),
     declaration_team_mate_id integer NOT NULL,
-    declaration_date date,
+    declaration_date timestamp with time zone,
     declaration_status character varying(30) COLLATE pg_catalog."default",
     CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id),
 	CONSTRAINT declaration_team_mate_id_fkey FOREIGN KEY (declaration_team_mate_id)

--- a/yaki_backend/src/db/create_tables.sql
+++ b/yaki_backend/src/db/create_tables.sql
@@ -81,7 +81,7 @@ ALTER SEQUENCE public.declaration_id_seq
 
 -- CREATE TABLE FOR USERS
 
-CREATE TABLE IF NOT EXISTS public.user
+CREATE TABLE IF NOT EXISTS public."user"
 (
     user_id integer NOT NULL DEFAULT nextval('user_id_seq'::regclass),
     user_last_name character varying(100) COLLATE pg_catalog."default",
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS public.user
 
 TABLESPACE pg_default;
 
-ALTER TABLE IF EXISTS public.user
+ALTER TABLE IF EXISTS public."user"
     OWNER to yaki;
 
 
@@ -174,10 +174,15 @@ ALTER TABLE IF EXISTS public.locations
 CREATE TABLE IF NOT EXISTS public.declaration
 (
     declaration_id integer NOT NULL DEFAULT nextval('declaration_id_seq'::regclass),
-    declaration_team_mate_id integer,
-    declaration_date timestamp with time zone,
+    declaration_team_mate_id integer NOT NULL,
+    declaration_date date,
     declaration_status character varying(30) COLLATE pg_catalog."default",
-    CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id)
+    CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id),
+	CONSTRAINT declaration_team_mate_id_fkey FOREIGN KEY (declaration_team_mate_id)
+		REFERENCES public.team_mate (team_mate_id) MATCH SIMPLE
+		ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
 )
 
 TABLESPACE pg_default;

--- a/yaki_database/create_tables.sql
+++ b/yaki_database/create_tables.sql
@@ -175,7 +175,7 @@ CREATE TABLE IF NOT EXISTS public.declaration
 (
     declaration_id integer NOT NULL DEFAULT nextval('declaration_id_seq'::regclass),
     declaration_team_mate_id integer NOT NULL,
-    declaration_date date,
+    declaration_date timestamp with time zone,
     declaration_status character varying(30) COLLATE pg_catalog."default",
     CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id),
 	CONSTRAINT declaration_team_mate_id_fkey FOREIGN KEY (declaration_team_mate_id)

--- a/yaki_database/create_tables.sql
+++ b/yaki_database/create_tables.sql
@@ -174,10 +174,15 @@ ALTER TABLE IF EXISTS public.locations
 CREATE TABLE IF NOT EXISTS public.declaration
 (
     declaration_id integer NOT NULL DEFAULT nextval('declaration_id_seq'::regclass),
-    declaration_team_mate_id integer,
+    declaration_team_mate_id integer NOT NULL,
     declaration_date date,
     declaration_status character varying(30) COLLATE pg_catalog."default",
-    CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id)
+    CONSTRAINT declaration_pkey PRIMARY KEY (declaration_id),
+	CONSTRAINT declaration_team_mate_id_fkey FOREIGN KEY (declaration_team_mate_id)
+		REFERENCES public.team_mate (team_mate_id) MATCH SIMPLE
+		ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
 )
 
 TABLESPACE pg_default;


### PR DESCRIPTION
# Description
We could create a declaration without a valid team_mate_id 

# Linked Issues
#126 

# Changes
You can't create a declaration with a team_mate_id value of null or with an unknown team mate

# Screenshots
N/A

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
N/A
