### PR TITLE
chore(java_build): create gradle build for java backend

### DIFF
--- a/.github/workflows/test_&_build.yaml
+++ b/.github/workflows/test_&_build.yaml
@@ -57,3 +57,16 @@ jobs:
           npm run swagger
           npm run test
           npm run build
+  java:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        run: |
+          cd yaki_admin_backend
+          ./gradlew clean build


### PR DESCRIPTION
# Description
What are changes related to ?
Add java build to workflow

# Changes
What does it change ?
yaki_admin_backend will build every time someone will make a pull request

Is is a breaking change ?
no

Is is a new feature ?
no

Is is a patch, fix, hotfix ?
no

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
