### PR TITLE
fix(UnableToUseSwagger): add body and header in swagger

### DIFF
--- a/.github/workflows/karate.yaml
+++ b/.github/workflows/karate.yaml
@@ -21,6 +21,7 @@ jobs:
           echo "Starting docker containers"
           docker compose up --build --quiet-pull -d
           echo "run swagger"
+          npm run swagger
           cd ../yaki_karate
           echo "Running karate tests"
           mvn test --quiet

--- a/.github/workflows/karate.yaml
+++ b/.github/workflows/karate.yaml
@@ -20,6 +20,8 @@ jobs:
           npm run swagger
           echo "Starting docker containers"
           docker compose up --build --quiet-pull -d
+          echo "run swagger"
+          npm run swagger
           cd ../yaki_karate
           echo "Running karate tests"
           mvn test --quiet

--- a/.github/workflows/karate.yaml
+++ b/.github/workflows/karate.yaml
@@ -21,7 +21,6 @@ jobs:
           echo "Starting docker containers"
           docker compose up --build --quiet-pull -d
           echo "run swagger"
-          npm run swagger
           cd ../yaki_karate
           echo "Running karate tests"
           mvn test --quiet

--- a/.github/workflows/karate.yaml
+++ b/.github/workflows/karate.yaml
@@ -20,8 +20,6 @@ jobs:
           npm run swagger
           echo "Starting docker containers"
           docker compose up --build --quiet-pull -d
-          echo "run swagger"
-          npm run swagger
           cd ../yaki_karate
           echo "Running karate tests"
           mvn test --quiet

--- a/yaki_backend/src/features/declaration/declaration.router.ts
+++ b/yaki_backend/src/features/declaration/declaration.router.ts
@@ -20,7 +20,7 @@ const declarationController = new DeclarationController(declarationService);
 declarationRouter.post(
   '/declarations',
   (req, res, next) =>
-    /* #swagger.parameters['obj'] = {
+    /* #swagger.parameters['declaration'] = {
                 in: 'body',
                 description: 'Declaration details',
                 required: true,
@@ -36,12 +36,12 @@ declarationRouter.post(
 declarationRouter.get(
   '/declarations',
   (req, res, next) =>
-    /*#swagger.parameters['declaration'] = {
+    /*#swagger.parameters['teamMateId'] = {
                 in: 'query',
                 description: 'Team mate id',
                 required: true,
                 type: 'number',
-                schema: { token: 1 }
+                schema: { teamMateId: 1 }
 }
   */
     authService.verifyToken(req, res, next),

--- a/yaki_backend/src/features/declaration/declaration.router.ts
+++ b/yaki_backend/src/features/declaration/declaration.router.ts
@@ -1,8 +1,8 @@
-import express, { Router } from "express";
-import { authService } from "../user/authentication.service";
-import { DeclarationController } from "./declaration.controller";
-import { DeclarationRepository } from "./declaration.repository";
-import { DeclarationService } from "./declaration.service";
+import express, { Router } from 'express';
+import { authService } from '../user/authentication.service';
+import { DeclarationController } from './declaration.controller';
+import { DeclarationRepository } from './declaration.repository';
+import { DeclarationService } from './declaration.service';
 
 /* Creating a new router object. */
 const declarationRouter: Router = express.Router();
@@ -16,11 +16,55 @@ const declarationService = new DeclarationService(declarationRepo);
 /* Creating a new instance of the DeclarationController class. */
 const declarationController = new DeclarationController(declarationService);
 
-
 /* Creating a new route for the declarationRouter object. */
-declarationRouter.post("/declarations", (req, res, next) => authService.verifyToken(req, res, next), (req, res) => { declarationController.createDeclaration(req, res) })
-declarationRouter.get("/declarations", (req, res, next) => authService.verifyToken(req, res, next), (req, res) => { declarationController.getDeclarationsForTeamMate(req, res) })
-declarationRouter.put("/declarations/:declarationId", (req, res, next) => authService.verifyToken(req, res, next), (req, res) => { declarationController.updateDeclarationStatus(req, res) })
+declarationRouter.post(
+  '/declarations',
+  (req, res, next) =>
+    /* #swagger.parameters['obj'] = {
+                in: 'body',
+                description: 'Declaration details',
+                required: true,
+                type: 'object',
+                schema: { declarationTeamMateId: 1, declarationStatus: 'string', declarationDate: 'string' }
+}
+  */
+    authService.verifyToken(req, res, next),
+  (req, res) => {
+    declarationController.createDeclaration(req, res);
+  }
+);
+declarationRouter.get(
+  '/declarations',
+  (req, res, next) =>
+    /*#swagger.parameters['declaration'] = {
+                in: 'query',
+                description: 'Team mate id',
+                required: true,
+                type: 'number',
+                schema: { token: 1 }
+}
+  */
+    authService.verifyToken(req, res, next),
+  (req, res) => {
+    declarationController.getDeclarationsForTeamMate(req, res);
+  }
+);
+declarationRouter.put(
+  '/declarations/:declarationId',
+  (req, res, next) =>
+    /*#swagger.parameters['declarationBody'] = {
+                in: 'body',
+                description: 'Declaration body',
+                required: true,
+                type: 'object',
+                schema: { declarationStatus: 'string', declarationDate: 'string', declarationTeamMateId: 1}
+}
+  */
+    authService.verifyToken(req, res, next),
+  (req, res) => {
+    declarationController.updateDeclarationStatus(req, res);
+  }
+);
 
 /* Exporting the declarationRouter object. */
 export default declarationRouter;

--- a/yaki_backend/src/router.ts
+++ b/yaki_backend/src/router.ts
@@ -51,7 +51,15 @@ router.get(
 
 router.get(
   '/teamMates',
-  (req, res, next) => authService.verifyToken(req, res, next),
+  (req, res, next) =>
+    /*#swagger.parameters['captainId'] = {
+                in: 'query',
+                description: 'Captain id',
+                required: true,
+                type: 'number',
+                schema: { captainId: 1 }
+}
+  */ authService.verifyToken(req, res, next),
   async (req, res) =>
     teamMateController.getByTeamIdWithLastDeclaration(req, res)
 );

--- a/yaki_backend/src/router.ts
+++ b/yaki_backend/src/router.ts
@@ -1,16 +1,16 @@
-import express from "express";
-import {UserController} from "./features/user/user.controller";
-import {UserService} from "./features/user/user.service";
-import {UserRepository} from "./features/user/user.repository";
-import {CaptainRepository} from "./features/captain/captain.repository";
-import {CaptainService} from "./features/captain/captain.service";
-import {TeamMateRepository} from "./features/teamMate/teamMate.repository";
-import {TeamMateService} from "./features/teamMate/teamMate.service";
-import {authService} from "./features/user/authentication.service";
-import {CaptainController} from "./features/captain/captain.controller";
-import { TeamMateController } from "./features/teamMate/teamMate.controller";
-import { TeamRepository } from "./features/team/team.repository";
-import { TeamService } from "./features/team/team.service";
+import express from 'express';
+import { UserController } from './features/user/user.controller';
+import { UserService } from './features/user/user.service';
+import { UserRepository } from './features/user/user.repository';
+import { CaptainRepository } from './features/captain/captain.repository';
+import { CaptainService } from './features/captain/captain.service';
+import { TeamMateRepository } from './features/teamMate/teamMate.repository';
+import { TeamMateService } from './features/teamMate/teamMate.service';
+import { authService } from './features/user/authentication.service';
+import { CaptainController } from './features/captain/captain.controller';
+import { TeamMateController } from './features/teamMate/teamMate.controller';
+import { TeamRepository } from './features/team/team.repository';
+import { TeamService } from './features/team/team.service';
 
 export const router = express.Router();
 
@@ -33,11 +33,25 @@ const userRepository = new UserRepository();
 const userService = new UserService(userRepository);
 const userController = new UserController(userService);
 
-router.post("/login", (req, res) => userController.checkLogin(req, res));
+router.post('/login', (req, res) =>
+  /* #swagger.parameters['obj'] = {
+                in: 'body',
+                description: 'Login details',
+                required: true,
+                type: 'object',
+                schema: { login: 'string', password: 'string' }
+} */
+  userController.checkLogin(req, res)
+);
 router.get(
-  "/captains",
+  '/captains',
   (req, res, next) => authService.verifyToken(req, res, next),
   (_, res) => captainController.getAll(_, res)
 );
 
-router.get("/teamMates",(req, res, next) => authService.verifyToken(req, res, next), async (req, res) => teamMateController.getByTeamIdWithLastDeclaration(req, res));
+router.get(
+  '/teamMates',
+  (req, res, next) => authService.verifyToken(req, res, next),
+  async (req, res) =>
+    teamMateController.getByTeamIdWithLastDeclaration(req, res)
+);

--- a/yaki_backend/src/router.ts
+++ b/yaki_backend/src/router.ts
@@ -34,7 +34,7 @@ const userService = new UserService(userRepository);
 const userController = new UserController(userService);
 
 router.post('/login', (req, res) =>
-  /* #swagger.parameters['obj'] = {
+  /* #swagger.parameters['Login'] = {
                 in: 'body',
                 description: 'Login details',
                 required: true,


### PR DESCRIPTION
# Description
The yaki_backend swagger interface was unusable. We cannot put the required parameters for the requests.
After this change, we can add headers and body parameters for requests.


# Linked Issues
What are the issues fixed by this pull request? 
Unable to use swagger on yaki_backend#138 (https://github.com/XPEHO/YAKI/issues/138)

# Changes
It is a change in swagger.json by adding parameters 

# Screenshots
![Capture d’écran du 2023-03-30 15-27-09](https://user-images.githubusercontent.com/92584130/228851510-ac2d6e84-3b1c-4331-94be-474475548f5d.png)

# Tests
How has it been tested?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
