### PR TITLE
chore(dependabot_update): change the dependabot updates frequency to …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,16 @@ updates:
   - package-ecosystem: "npm"
     directory: "/yaki_backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pub"
     directory: "/yaki_mobile"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gradle"
     directory: "/yaki_admin_backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "maven"
     directory: "/yaki_karate"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION

# Description
As a developer 
I want to change the dependabot updates on our dependencies from weekly to monthly
In order to save time each week. 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [X ] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
