### PR TITLE
chore(sonar): add jacoco plugin for test coverage

### DIFF
--- a/yaki_admin_backend/build.gradle
+++ b/yaki_admin_backend/build.gradle
@@ -3,13 +3,14 @@ plugins {
     id 'org.springframework.boot' version '3.0.6'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'org.sonarqube' version '4.0.0.2929'
+    id 'jacoco'
 }
 
 sonarqube {
-  properties {
-    property("sonar.projectKey", "yaki_admin_backend")
-    property("sonar.projectName", "yaki_admin_backend")
-  }
+    properties {
+        property("sonar.projectKey", "yaki_admin_backend")
+        property("sonar.projectName", "yaki_admin_backend")
+    }
 }
 
 group = 'com.xpeho'
@@ -32,10 +33,23 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'com.h2database:h2'
+    // ad jacoco for sonar scan coverage
+    testImplementation 'org.jacoco:org.jacoco.core:0.8.8'
 
     test {
         useJUnitPlatform()
         systemProperty 'spring.config.name', 'application-test'
+        finalizedBy jacocoTestReport // report is always generated after tests run
+    }
+    jacocoTestReport {
+        reports {
+            xml.required = true
+        }
+        dependsOn test // tests are required to run before generating the report
+    }
+
+    jacoco {
+        toolVersion = "0.8.8"
     }
 }
 


### PR DESCRIPTION
# Description
What are changes related to ?
Jacoco plugin added to admin backend in order to get test coverage on Sonarqube

# Linked Issues
What are the issues fixed by this pull request ?
None

# Changes
What does it change ?
Each time we will push on branches, Sonarqube will also update coverage on scan

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information

Based on the following documentation [https://docs.gradle.org/current/userguide/jacoco_plugin.html](https://docs.gradle.org/current/userguide/jacoco_plugin.html)
