### PR TITLE
Fix/admin front end env at runtime

### DIFF
--- a/yaki_admin/dockerfile
+++ b/yaki_admin/dockerfile
@@ -1,21 +1,16 @@
-FROM node:lts-alpine
-# install simple http server for serving static content
-# make the 'app' folder the current working directory
+FROM node:lts-alpine as build-stage
 RUN mkdir /app
-
 WORKDIR /app
-# copy both 'package.json' and 'package-lock.json' (if available)
-COPY ["package.json", "package-lock.json*", "./"]
-# install project dependencies
-RUN npm install --silent 
-RUN npm install -g http-server 
-RUN npm install --global npm-run-all
-
-# copy project files and folders to the current working directory (i.e. 'app' folder)
+COPY package*.json ./
+RUN npm install
 COPY . .
-# build app for production with minification
 RUN npm run build
 
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
 
-EXPOSE 4173
-CMD ["http-server", "dist", "-p", "4173"]
+COPY ./substitute_environment_variables.sh /substitute_environment_variables.sh
+RUN chmod +x /substitute_environment_variables.sh
+ENTRYPOINT ["/substitute_environment_variables.sh"]
+
+EXPOSE 80

--- a/yaki_admin/dockerfile
+++ b/yaki_admin/dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN npm run build
+RUN npm run build-uat
 
 FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html

--- a/yaki_admin/package.json
+++ b/yaki_admin/package.json
@@ -7,8 +7,10 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "build": "run-p type-check build-only",
+    "build-uat": "run-p type-check build-only-uat",
     "preview": "vite preview",
     "build-only": "vite build",
+    "build-only-uat": "vite build --base=/admin-ui/",
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },

--- a/yaki_admin/src/envPlaceholder.ts
+++ b/yaki_admin/src/envPlaceholder.ts
@@ -1,0 +1,3 @@
+export const environmentVar = {
+  baseURL: "URL_PLACEHOLDER",
+};

--- a/yaki_admin/src/features/captain/components/SideBarCaptainContent.vue
+++ b/yaki_admin/src/features/captain/components/SideBarCaptainContent.vue
@@ -12,7 +12,7 @@ const teams = reactive({
   list: [] as TeamType[],
 });
 onBeforeMount(async () => {
-  teams.list = await teamService.getAllTeamsWithinCaptain(2);
+  teams.list = await teamService.getAllTeamsWithinCaptain(343);
 });
 const selectedTeam = (id: number) => {
   isTeamSelected.setTeam(id);

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -2,7 +2,6 @@ import type {TeamType} from "./team.type";
 import {environmentVar} from "@/envPlaceholder";
 
 const URL: string = environmentVar.baseURL;
-console.log(URL);
 
 export class TeamService {
   /* `getAllTeamsWithinCaptain` is a method of the `TeamService` class that takes in a `number`

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -1,6 +1,8 @@
 import type {TeamType} from "./team.type";
+import {environmentVar} from "@/envPlaceholder";
 
-const URL: string | undefined = import.meta.env.VITE_API_URL;
+const URL: string = environmentVar.baseURL;
+console.log(URL);
 
 export class TeamService {
   /* `getAllTeamsWithinCaptain` is a method of the `TeamService` class that takes in a `number`

--- a/yaki_admin/src/services/teamMate.service.ts
+++ b/yaki_admin/src/services/teamMate.service.ts
@@ -1,6 +1,7 @@
 import type {TeamMateType} from "./teamMate.type";
+import {environmentVar} from "@/envPlaceholder";
 
-const URL: string | undefined = import.meta.env.VITE_API_URL;
+const URL: string = environmentVar.baseURL;
 
 // Defining a TeamMateService class to handle HTTP requests to the API
 export class TeamMateService {

--- a/yaki_admin/substitute_environment_variables.sh
+++ b/yaki_admin/substitute_environment_variables.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Replace env vars in files served by NGINX
+for file in usr/share/nginx/html/assets/*.js;
+do 
+  sed -i -e 's|URL_PLACEHOLDER|'${VUE3_URL}'|g' $file
+done
+
+  # Starting NGINX
+nginx -g 'daemon off;'


### PR DESCRIPTION
# Description
Allow vue3-vite to change environment variable at runtime, so create a agnostic docker image

# Linked Issues
#447 

# Changes
What does it change ? agnostic docker dimage
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ? fix

# Screenshots
No

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
No
