### PR TITLE
feat(show-password): add button to show plain text password

### DIFF
--- a/yaki_mobile/lib/presentation/ui/shared/views/input_app.dart
+++ b/yaki_mobile/lib/presentation/ui/shared/views/input_app.dart
@@ -25,14 +25,38 @@ class InputApp extends StatefulWidget {
 class _InputAppState extends State<InputApp> {
   TextEditingController controller = TextEditingController();
 
+  // state used to choose the password display mode (hidden or visible)
+  late bool _passwordVisible;
+
+  @override
+  void initState() {
+    super.initState();
+    _passwordVisible = widget.password;
+  }
+
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: widget.controller,
-      obscureText: widget.password,
+      obscureText: _passwordVisible,
       decoration: InputDecoration(
         hintText: widget.inputText,
         border: const OutlineInputBorder(),
+        suffixIconColor: Colors.grey,
+        suffixIcon: widget.password
+            ? IconButton(
+                icon: Icon(
+                  _passwordVisible ? Icons.visibility : Icons.visibility_off,
+                ),
+                onPressed: () {
+                  setState(
+                    () {
+                      _passwordVisible = !_passwordVisible;
+                    },
+                  );
+                },
+              )
+            : null,
       ),
     );
   }


### PR DESCRIPTION
# Description
Added a button to let user to see its input when he tries to entrer its password

# Linked Issues
#284 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
