### PR TITLE
fix(captain-view-halfday-declaration): can now properly distinguished fullday and halfday declarations of teamMates of a team

### DIFF
--- a/yaki_mobile/lib/data/repositories/team_mate_repository.dart
+++ b/yaki_mobile/lib/data/repositories/team_mate_repository.dart
@@ -27,20 +27,45 @@ class TeamMateRepository {
         case 200:
           final modelList = setTeamMateModelList(listHttpResponse);
 
-          teamMatelist = modelList.map(
-            (e) {
-              final statusInCamelCase = StatusUtils.toCamelCase(
-                toFormat: e.declarationStatus ?? 'undeclared',
-                splitChar: ' ',
+          List<TeamMateEntity> teamMatelist = <TeamMateEntity>[];
+
+          for (var i = 0; i < modelList.length; i++) {
+            final statusInCamelCase = StatusUtils.toCamelCase(
+              toFormat: modelList[i].declarationStatus ?? 'undeclared',
+              splitChar: ' ',
+            );
+
+            if (i != 0 && modelList[i].userId == modelList[i - 1].userId) {
+              teamMatelist.last.addHalfDayDeclaration(statusInCamelCase);
+            } else {
+              teamMatelist.add(
+                TeamMateEntity(
+                  userFirstName: modelList[i].userFirstName,
+                  userLastName: modelList[i].userLastName,
+                  declarationDate: modelList[i].declarationDate,
+                  declarationStatus: statusInCamelCase,
+                ),
               );
-              return TeamMateEntity(
-                userFirstName: e.userFirstName,
-                userLastName: e.userLastName,
-                declarationDate: e.declarationDate,
-                declarationStatus: statusInCamelCase,
-              );
-            },
-          ).toList();
+            }
+          }
+
+          // modelList.map(
+          //   (e) {
+          //     final statusInCamelCase = StatusUtils.toCamelCase(
+          //       toFormat: e.declarationStatus ?? 'undeclared',
+          //       splitChar: ' ',
+          //     );
+          //     teamMatelist.add(
+          //       TeamMateEntity(
+          //         userFirstName: e.userFirstName,
+          //         userLastName: e.userLastName,
+          //         declarationDate: e.declarationDate,
+          //         declarationStatus: statusInCamelCase,
+          //       ),
+          //     );
+          //   },
+          // ).toList();
+
           return teamMatelist;
         default:
           throw Exception('Invalid statusCode : $statusCode');

--- a/yaki_mobile/lib/data/repositories/team_mate_repository.dart
+++ b/yaki_mobile/lib/data/repositories/team_mate_repository.dart
@@ -49,23 +49,6 @@ class TeamMateRepository {
             }
           }
 
-          // modelList.map(
-          //   (e) {
-          //     final statusInCamelCase = StatusUtils.toCamelCase(
-          //       toFormat: e.declarationStatus ?? 'undeclared',
-          //       splitChar: ' ',
-          //     );
-          //     teamMatelist.add(
-          //       TeamMateEntity(
-          //         userFirstName: e.userFirstName,
-          //         userLastName: e.userLastName,
-          //         declarationDate: e.declarationDate,
-          //         declarationStatus: statusInCamelCase,
-          //       ),
-          //     );
-          //   },
-          // ).toList();
-
           return teamMatelist;
         default:
           throw Exception('Invalid statusCode : $statusCode');

--- a/yaki_mobile/lib/domain/entities/team_mate_entity.dart
+++ b/yaki_mobile/lib/domain/entities/team_mate_entity.dart
@@ -3,13 +3,19 @@ class TeamMateEntity {
   String? userLastName;
   DateTime? declarationDate;
   String? declarationStatus;
+  List<String>? halfDayDeclarationStatus;
 
   TeamMateEntity({
     required this.userFirstName,
     required this.userLastName,
     required this.declarationDate,
-    required this.declarationStatus,
+    this.declarationStatus,
   });
+
+  addHalfDayDeclaration(String afternoonDeclaration) {
+    halfDayDeclarationStatus = [declarationStatus!, afternoonDeclaration];
+    declarationStatus = null;
+  }
 
   // method override for unit test purpose,
   // allow to compare instance with == operator
@@ -19,6 +25,7 @@ class TeamMateEntity {
         userLastName.hashCode,
         declarationDate.hashCode,
         declarationStatus.hashCode,
+        halfDayDeclarationStatus.hashCode,
       );
 
   // method override for unit test purpose,

--- a/yaki_mobile/lib/presentation/ui/captain/views/captain_body.dart
+++ b/yaki_mobile/lib/presentation/ui/captain/views/captain_body.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaki/presentation/state/providers/team_mate_provider.dart';
 import 'package:yaki/presentation/ui/captain/views/team_mate_card.dart';
+import 'package:yaki/presentation/ui/captain/views/team_mate_card_halfday.dart';
 
 /// using ConsumerStatefulWidget (statefullWidget) to have access to the WidgetRef object
 /// allowing the current widget to have access to any provider.
@@ -41,13 +42,22 @@ class _CaptainBodyState extends ConsumerState<CaptainBody> {
         // This widget allows you to create a list object and iterate on it
         itemCount: listTeamMate.length,
         itemBuilder: (context, index) {
-          return CardTeamMate(
-            // Cards of the Team Mate
-            firstName: (listTeamMate[index].userFirstName),
-            lastName: (listTeamMate[index].userLastName),
-            dateActu: (listTeamMate[index].declarationDate),
-            status: (listTeamMate[index].declarationStatus),
-          );
+          if (listTeamMate[index].declarationStatus == null) {
+            return CardTeamMateHalfday(
+              firstName: (listTeamMate[index].userFirstName),
+              lastName: (listTeamMate[index].userLastName),
+              dateActu: (listTeamMate[index].declarationDate),
+              status: (listTeamMate[index].halfDayDeclarationStatus),
+            );
+          } else {
+            return CardTeamMate(
+              // Cards of the Team Mate
+              firstName: (listTeamMate[index].userFirstName),
+              lastName: (listTeamMate[index].userLastName),
+              dateActu: (listTeamMate[index].declarationDate),
+              status: (listTeamMate[index].declarationStatus),
+            );
+          }
         },
       ),
     );

--- a/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card.dart
+++ b/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card.dart
@@ -124,7 +124,7 @@ class _CardTeamMateState extends State<CardTeamMate> {
                               style: TextStyle(
                                 fontSize: 22,
                                 fontWeight: FontWeight.w700,
-                                color: Colors.grey,
+                                color: Colors.black45,
                               ),
                             ),
                             Text(

--- a/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card_halfday.dart
+++ b/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card_halfday.dart
@@ -167,7 +167,7 @@ class _CardTeamMateState extends State<CardTeamMateHalfday> {
                             ),
                           ],
                         ),
-                      )
+                      ),
                     ],
                   ),
                 ),

--- a/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card_halfday.dart
+++ b/yaki_mobile/lib/presentation/ui/captain/views/team_mate_card_halfday.dart
@@ -6,9 +6,9 @@ import 'package:flutter_svg/svg.dart';
 import 'package:yaki/presentation/displaydata/status_page_content.dart';
 import 'package:yaki/presentation/styles/header_text_style.dart';
 
-class CardTeamMate extends StatefulWidget {
+class CardTeamMateHalfday extends StatefulWidget {
   /// Card with the Team Mate's avatar, name, update date and status
-  const CardTeamMate({
+  const CardTeamMateHalfday({
     super.key,
     required this.firstName,
     required this.lastName,
@@ -18,14 +18,14 @@ class CardTeamMate extends StatefulWidget {
 
   final String? firstName;
   final String? lastName;
-  final String? status;
+  final List<String>? status;
   final DateTime? dateActu;
 
   @override
-  State<CardTeamMate> createState() => _CardTeamMateState();
+  State<CardTeamMateHalfday> createState() => _CardTeamMateState();
 }
 
-class _CardTeamMateState extends State<CardTeamMate> {
+class _CardTeamMateState extends State<CardTeamMateHalfday> {
   @override
   Widget build(BuildContext context) {
     // recovers device dimensions
@@ -70,7 +70,7 @@ class _CardTeamMateState extends State<CardTeamMate> {
                             child: Padding(
                               padding: const EdgeInsets.all(10),
                               child: SvgPicture.asset(
-                                StatusUtils.getImage(widget.status ?? ""),
+                                StatusUtils.getImage(widget.status!.first),
                                 width: 40,
                                 height: 40,
                               ),
@@ -94,7 +94,6 @@ class _CardTeamMateState extends State<CardTeamMate> {
                             style: const TextStyle(
                               fontWeight: FontWeight.bold,
                               fontSize: 20,
-                              color: Colors.black,
                             ),
                           )
                         ],
@@ -120,17 +119,45 @@ class _CardTeamMateState extends State<CardTeamMate> {
                           children: [
                             const Text(
                               // Status of the Team Mate
-                              'Journée :',
+                              'Matin :',
                               style: TextStyle(
                                 fontSize: 22,
                                 fontWeight: FontWeight.w700,
-                                color: Colors.grey,
+                                color: Colors.black45,
                               ),
                             ),
                             Text(
                               // Status of the Team Mate
                               widget.status != null
-                                  ? tr(widget.status!)
+                                  ? tr(widget.status!.first)
+                                  : 'Undeclared',
+                              style: const TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.w700,
+                                color: HeaderColor.yellowApp,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(
+                        width: size.width * 0.60,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            const Text(
+                              // Status of the Team Mate
+                              'Aprem :',
+                              style: TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.black45,
+                              ),
+                            ),
+                            Text(
+                              // Status of the Team Mate
+                              widget.status != null
+                                  ? tr(widget.status!.last)
                                   : 'Undeclared',
                               style: const TextStyle(
                                 fontSize: 22,

--- a/yaki_mobile/test/unit/data/repositories/team_mate_repository_test.dart
+++ b/yaki_mobile/test/unit/data/repositories/team_mate_repository_test.dart
@@ -27,12 +27,14 @@ void main() {
           String captainId = "1";
           List<Map<String, dynamic>> getResponseAsJson = [
             {
+              "userId": 1,
               "userFirstName": "Dupond",
               "userLastName": "Dupond",
               "declarationDate": '2023-03-20T10:00:00.950Z',
               "declarationStatus": "vacation",
             },
             {
+              "userId": 2,
               "userFirstName": "Jean",
               "userLastName": "Val",
               "declarationDate": '2023-03-20T10:00:00.950Z',
@@ -64,6 +66,8 @@ void main() {
 
           List<TeamMateEntity> teamMatelist =
               await teamMateRepository.getTeamMate(captainId);
+
+          print(teamMatelist);
 
           expect(listEquals(teamMatelist, teamMatelistReturned), true);
         },

--- a/yaki_mobile/test/unit/data/repositories/team_mate_repository_test.dart
+++ b/yaki_mobile/test/unit/data/repositories/team_mate_repository_test.dart
@@ -67,8 +67,6 @@ void main() {
           List<TeamMateEntity> teamMatelist =
               await teamMateRepository.getTeamMate(captainId);
 
-          print(teamMatelist);
-
           expect(listEquals(teamMatelist, teamMatelistReturned), true);
         },
       );


### PR DESCRIPTION
# Description
Can now properly distinguished halfday and fullday declarations on captain view

# Linked Issues
#488 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
