### PR TITLE
feat(back_admin_assign_captain): test+implementation

### DIFF
--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/CaptainsTeamsModel.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/CaptainsTeamsModel.java
@@ -15,7 +15,10 @@ public class CaptainsTeamsModel {
         this.captainModel = captainModel;
         this.teamModel = teamModel;
     }
-
+    public CaptainsTeamsModel(int captainId, int teamId) {
+        this.captainId = captainId;
+        this.teamId = teamId;
+    }
     public CaptainsTeamsModel() {
     }
     @ManyToOne()
@@ -25,6 +28,14 @@ public class CaptainsTeamsModel {
     @ManyToOne()
     @JoinColumn(name = "captains_teams_team_id", insertable = false, updatable = false)
     private TeamModel teamModel;
+
+    @Column(name = "captains_teams_captain_id")
+    private int captainId;
+
+    @Column(name = "captains_teams_team_id")
+    private int teamId;
+
+
 
     public int getId() {
         return id;
@@ -48,5 +59,21 @@ public class CaptainsTeamsModel {
 
     public void setTeamModel(TeamModel teamModel) {
         this.teamModel = teamModel;
+    }
+
+    public int getCaptainId() {
+        return captainId;
+    }
+
+    public void setCaptainId(int captainId) {
+        this.captainId = captainId;
+    }
+
+    public int getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(int teamId) {
+        this.teamId = teamId;
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/CaptainsTeamsServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/CaptainsTeamsServiceImpl.java
@@ -21,4 +21,8 @@ public class CaptainsTeamsServiceImpl implements CaptainsTeamsService {
         return captainsTeamsJpaRepository.findAllTeamsByCaptain(id);
 
     }
+    public boolean assignCaptainToTeam(int captainId, int teamId) {
+        captainsTeamsJpaRepository.save(new CaptainsTeamsModel(captainId, teamId));
+        return true;
+    }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/CaptainService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/CaptainService.java
@@ -23,4 +23,5 @@ public interface CaptainService {
 
     CaptainEntity disabled(int id);
 
+    CaptainEntity assign(int id, Integer teamId);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/CaptainController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/CaptainController.java
@@ -54,4 +54,8 @@ public class CaptainController {
     public CaptainEntity disabled(@PathVariable int id){
         return captainService.disabled(id);
     }
+    @PutMapping("/assign/{id}")
+    public CaptainEntity assign(@PathVariable int id, @RequestBody Integer teamId ){
+        return captainService.assign(id,teamId);
+    }
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/CaptainServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/CaptainServiceImplTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.net.HttpCookie;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +36,10 @@ class CaptainServiceImplTest {
 
     @MockBean
     private EntityLogServiceImpl entityLogService;
+
+    @MockBean
+    private CaptainsTeamsServiceImpl captainsTeamsService;
+
     private EntityLogModel entityLogModel;
 
     @BeforeEach
@@ -174,5 +179,17 @@ class CaptainServiceImplTest {
 
         //then
         assertEquals(expectedCaptainEntities, actualCaptainEntities);
+    }
+
+    @Test
+    public void testAssign() {
+        //given
+        int captainId = 3;
+        int teamId = 5;
+        when(captainJpaRepository.findById(captainId)).thenReturn(Optional.of(new CaptainModel(captainId, 1, 2, entityLogModel.getId())));
+        when(captainsTeamsService.assignCaptainToTeam(captainId, teamId)).thenReturn(true);
+        CaptainEntity captainEntityExpected = new CaptainEntity(captainId, 1, 2);
+        CaptainEntity captainEntityTested = captainService.assign(captainId, teamId);
+        assertEquals(captainEntityExpected, captainEntityTested);
     }
 }


### PR DESCRIPTION
# Description
Add back admin route to assign a captain to an existing team

# Linked Issues
#687 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [ X] Manually
- [X ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
