### PR TITLE
Feat/spring forgotten password

### DIFF
--- a/yaki_admin_backend/build.gradle
+++ b/yaki_admin_backend/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'com.h2database:h2:2.1.214'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     // ad jacoco for sonar scan coverage
     testImplementation 'org.jacoco:org.jacoco.core:0.8.10'
 

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/VerificationTokenModel.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/VerificationTokenModel.java
@@ -26,7 +26,6 @@ public class VerificationTokenModel {
 
     @Column(name = "expiration_date")
     private Date expiryDate;
-//is it working properly ? test with 1 minute
     private Date calculateExpiryDate(int expiryTimeInMinutes) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date(System.currentTimeMillis()));

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImpl.java
@@ -14,6 +14,7 @@ import com.xpeho.yaki_admin_backend.events.OnRegistrationCompleteEvent;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -76,12 +77,16 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     @Override
     public AuthenticationResponseEntity authenticate(AuthenticationRequestEntity request) {
-        authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        request.login(),
-                        request.password()
-                )
-        );
+        try{
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            request.login(),
+                            request.password()
+                    )
+            );
+        }catch (Exception e){
+            throw new BadCredentialsException("bad credentials");
+        }
         UserModel user = repository.findByLogin(request.login())
                 .orElseThrow();
         if(user.isEnabled() == false){
@@ -117,7 +122,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         if(!user.isPresent()){
             throw new EntityNotFoundException("no user found with this email");
         }
-        userService.resetPassword(user.get());
+        userService.resetPassword(user.get(),this.passwordEncoder);
 
         //send email
 

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImpl.java
@@ -117,16 +117,17 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
 
     @Override
-    public String forgotPassword(String email){
+    public void forgotPassword(String email){
         Optional<UserModel> user = repository.findByLogin(email);
         if(!user.isPresent()){
             throw new EntityNotFoundException("no user found with this email");
         }
-        userService.resetPassword(user.get(),this.passwordEncoder);
-
-        //send email
-
-        return "a token has been sent to your email";
+        try{
+            userService.resetPassword(user.get(),this.passwordEncoder);
+        }catch (Exception e){
+            throw new RuntimeException("an error has occured while trying to reset your password");
+        }
+        //send an email
     }
 
 

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImpl.java
@@ -9,12 +9,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class PasswordServiceImpl {
+
     public String generatePassword(int length) {
         String pwString = generateRandomSpecialCharacters(2)
                 .concat(generateRandomNumbers(2))
                 .concat(generateRandomAlphabet(2, true))
-                .concat(generateRandomAlphabet(2, false))
-                .concat(generateRandomCharacters(2));
+                .concat(generateRandomAlphabet(length-6, false));
+
         List<Character> pwChars = pwString.chars()
                 .mapToObj(data -> (char) data)
                 .collect(Collectors.toList());
@@ -37,9 +38,6 @@ public class PasswordServiceImpl {
     }
     public String generateRandomAlphabet(int length, boolean upperCase) {
         return generateCharactersInRange(length, upperCase ? 65 : 97, upperCase ? 90 : 122);
-    }
-    public String generateRandomCharacters(int length) {
-        return generateCharactersInRange(length, 33, 126);
     }
 
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImpl.java
@@ -1,0 +1,45 @@
+package com.xpeho.yaki_admin_backend.data.services;
+
+import org.apache.commons.text.RandomStringGenerator;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class PasswordServiceImpl {
+    public String generatePassword(int length) {
+        String pwString = generateRandomSpecialCharacters(2)
+                .concat(generateRandomNumbers(2))
+                .concat(generateRandomAlphabet(2, true))
+                .concat(generateRandomAlphabet(2, false))
+                .concat(generateRandomCharacters(2));
+        List<Character> pwChars = pwString.chars()
+                .mapToObj(data -> (char) data)
+                .collect(Collectors.toList());
+        Collections.shuffle(pwChars);
+        String password = pwChars.stream()
+                .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
+                .toString();
+        return password;
+    }
+    public String generateCharactersInRange(int length,int rangeStart, int rangeEnd) {
+        RandomStringGenerator pwdGenerator = new RandomStringGenerator.Builder().withinRange(rangeStart, rangeEnd)
+                .build();
+        return pwdGenerator.generate(length);
+    }
+    public String generateRandomSpecialCharacters(int length) {
+        return generateCharactersInRange(length, 33, 45);
+    }
+    public String generateRandomNumbers(int length) {
+        return generateCharactersInRange(length, 48, 57);
+    }
+    public String generateRandomAlphabet(int length, boolean upperCase) {
+        return generateCharactersInRange(length, upperCase ? 65 : 97, upperCase ? 90 : 122);
+    }
+    public String generateRandomCharacters(int length) {
+        return generateCharactersInRange(length, 33, 126);
+    }
+
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeammateServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeammateServiceImpl.java
@@ -40,9 +40,6 @@ public class TeammateServiceImpl implements TeammateService {
             UserEntityWithID userEntityWithID = new UserEntityWithID(id, null,teammateId, lastname, firstname, email);
             userEntityWithIDList.add(userEntityWithID);
         }
-        for(UserEntityWithID element: userEntityWithIDList) {
-            System.out.println(element.lastname());
-        }
         return userEntityWithIDList;
     }
 

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
@@ -140,7 +140,5 @@ public class UserServiceImpl implements UserService {
         userJpaRepository.save(user);
         eventPublisher.publishEvent(new OnResetPasswordCompletEvent(user, temporaryPassword));
     }
-
     //I used common text from apache because Passay present a security hotspot.
-
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeammateDetailsEntity.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeammateDetailsEntity.java
@@ -1,0 +1,3 @@
+package com.xpeho.yaki_admin_backend.domain.entities;
+
+public record TeammateDetailsEntity(int id, int teamId, int userId, String firstName, String lastName, String email) {}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeammateDetailsEntity.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeammateDetailsEntity.java
@@ -1,3 +1,0 @@
-package com.xpeho.yaki_admin_backend.domain.entities;
-
-public record TeammateDetailsEntity(int id, int teamId, int userId, String firstName, String lastName, String email) {}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/AuthenticationService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/AuthenticationService.java
@@ -13,5 +13,5 @@ public interface AuthenticationService {
 
     String confirmRegister(String token);
 
-    String forgotPassword(String email);
+    void forgotPassword(String email);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/AuthenticationService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/AuthenticationService.java
@@ -12,4 +12,6 @@ public interface AuthenticationService {
     AuthenticationResponseEntity authenticate(AuthenticationRequestEntity request);
 
     String confirmRegister(String token);
+
+    String forgotPassword(String email);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
@@ -16,4 +16,7 @@ public interface UserService {
     List<UserEntityWithID> findUserByIdRange(int idStart, int idEnd);
 
     UserEntity deleteById(int id);
+
+
+    String changePassword(String email, String oldPassword, String newPassword);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
@@ -5,6 +5,7 @@ import com.xpeho.yaki_admin_backend.domain.entities.UserEntity;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntityIn;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntityWithID;
 
+import java.rmi.UnexpectedException;
 import java.util.List;
 
 public interface UserService {
@@ -17,6 +18,5 @@ public interface UserService {
 
     UserEntity deleteById(int id);
 
-
-    String changePassword(String email, String oldPassword, String newPassword);
+    void changePassword(int id, String oldPassword, String newPassword);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/UserService.java
@@ -1,11 +1,9 @@
 package com.xpeho.yaki_admin_backend.domain.services;
 
-import com.xpeho.yaki_admin_backend.data.models.UserModel;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntity;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntityIn;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntityWithID;
 
-import java.rmi.UnexpectedException;
 import java.util.List;
 
 public interface UserService {

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/error_handling/CustomExceptionHandler.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/error_handling/CustomExceptionHandler.java
@@ -2,6 +2,7 @@ package com.xpeho.yaki_admin_backend.error_handling;
 
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -19,6 +20,12 @@ public class CustomExceptionHandler {
     @ExceptionHandler(EmailAlreadyExistsException.class)
     @ResponseStatus(HttpStatus.EXPECTATION_FAILED)
     public String handleEmailAlreadyExistsException(EmailAlreadyExistsException ex){
+        return ex.getMessage();
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public String handleBadCredentialsException(BadCredentialsException ex){
         return ex.getMessage();
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/events/OnResetPasswordCompletEvent.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/events/OnResetPasswordCompletEvent.java
@@ -1,0 +1,34 @@
+package com.xpeho.yaki_admin_backend.events;
+
+import com.xpeho.yaki_admin_backend.data.models.UserModel;
+import org.springframework.context.ApplicationEvent;
+
+public class OnResetPasswordCompletEvent extends ApplicationEvent {
+    private UserModel user;
+    private String password;
+    private final String appUrl = "";
+
+    public String getAppUrl() {
+        return appUrl;
+    }
+
+    public OnResetPasswordCompletEvent(
+            UserModel user, String password) {
+        super(user);
+        this.user = user;
+        this.password = password;
+    }
+
+    public UserModel getUser() {
+        return user;
+    }
+
+    public void setUser(UserModel user) {
+        this.user = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/EmailListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/EmailListener.java
@@ -1,0 +1,65 @@
+package com.xpeho.yaki_admin_backend.listeners;
+
+import com.mailjet.client.ClientOptions;
+import com.mailjet.client.MailjetClient;
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.MailjetResponse;
+import com.mailjet.client.errors.MailjetException;
+import com.mailjet.client.errors.MailjetSocketTimeoutException;
+import com.mailjet.client.resource.Emailv31;
+import com.xpeho.yaki_admin_backend.data.services.VerificationTokenServiceImpl;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class EmailListener<E extends ApplicationEvent> implements ApplicationListener<E> {
+    @Autowired
+    private VerificationTokenServiceImpl service;
+    @Value("${MAILJET_API_KEY:key}")
+    String apiKey;
+    @Value("${MAILJET_SECRET_KEY:secret}")
+    String secretKey;
+    //only for testing purposes, we need to give the email of the person
+    @Value("${MAILJET_SENDER_EMAIL:mail}")
+    String senderEmail;
+    @Value("${ADMIN_API_URL:url}")
+    String apiUrl;
+    protected MailjetRequest request;
+    @Override
+    public void onApplicationEvent(E event) {
+        try {
+            this.sendEmail(event);
+        } catch (MailjetSocketTimeoutException e) {
+            throw new RuntimeException(e);
+        } catch (MailjetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    protected abstract void sendEmail(E event) throws MailjetSocketTimeoutException, MailjetException;
+    protected void setSenderEmail(String toEmail, String subject, String text, String customerId) throws MailjetSocketTimeoutException, MailjetException{
+        request = new MailjetRequest(Emailv31.resource)
+                .property(Emailv31.MESSAGES, new JSONArray()
+                        .put(new JSONObject()
+                                .put(Emailv31.Message.FROM, new JSONObject()
+                                        .put("Email", senderEmail)
+                                        .put("Name", "Do not reply"))
+                                .put(Emailv31.Message.TO, new JSONArray()
+                                        .put(new JSONObject()
+                                                .put("Email", toEmail)
+                                                .put("Name", "Do not reply")))
+                                .put(Emailv31.Message.SUBJECT, subject)
+                                .put(Emailv31.Message.TEXTPART, "Yaki")
+                                .put(Emailv31.Message.HTMLPART, text)
+                                .put(Emailv31.Message.CUSTOMID, customerId)));
+        MailjetClient client = new MailjetClient(apiKey,secretKey,new ClientOptions("v3.1"));
+        if(!apiKey.equals("key") ) {
+            MailjetResponse response = client.post(request);
+        }
+
+    }
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/RegistrationListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/RegistrationListener.java
@@ -17,7 +17,6 @@ public class RegistrationListener extends EmailListener<OnRegistrationCompleteEv
 
     @Override
     protected void sendEmail(OnRegistrationCompleteEvent event) throws MailjetSocketTimeoutException, MailjetException {
-        System.out.println("Sending email 1");
         UserModel user = event.getUser();
         String token = UUID.randomUUID().toString();
         service.createVerificationToken(user, token);

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/RegistrationListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/RegistrationListener.java
@@ -1,57 +1,23 @@
 package com.xpeho.yaki_admin_backend.listeners;
 
 import com.mailjet.client.errors.MailjetException;
-import com.mailjet.client.resource.Email;
 import com.xpeho.yaki_admin_backend.data.models.UserModel;
 import com.xpeho.yaki_admin_backend.data.services.VerificationTokenServiceImpl;
-import com.xpeho.yaki_admin_backend.domain.services.VerificationTokenService;
 import com.xpeho.yaki_admin_backend.events.OnRegistrationCompleteEvent;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
-import com.mailjet.client.MailjetRequest;
 import com.mailjet.client.errors.MailjetSocketTimeoutException;
-import com.mailjet.client.MailjetClient;
-import com.mailjet.client.MailjetRequest;
-import com.mailjet.client.MailjetResponse;
-import com.mailjet.client.ClientOptions;
-import com.mailjet.client.resource.Emailv31;
 
 import java.util.UUID;
 
 @Component
-public class RegistrationListener implements ApplicationListener<OnRegistrationCompleteEvent> {
+public class RegistrationListener extends EmailListener<OnRegistrationCompleteEvent> {
     @Autowired
     private VerificationTokenServiceImpl service;
-    @Value("${MAILJET_API_KEY:key}")
-    String apiKey;
-    @Value("${MAILJET_SECRET_KEY:secret}")
-    String secretKey;
-    //only for testing purposes, we need to give the email of the person
-    @Value("${MAILJET_SENDER_EMAIL:mail}")
-    String senderEmail;
-    @Value("${ADMIN_API_URL:url}")
-    String apiUrl;
 
     @Override
-    public void onApplicationEvent(OnRegistrationCompleteEvent event) {
-        try {
-            this.confirmRegistration(event);
-        } catch (MailjetSocketTimeoutException e) {
-            throw new RuntimeException(e);
-        } catch (MailjetException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void confirmRegistration(OnRegistrationCompleteEvent event) throws MailjetSocketTimeoutException, MailjetException {
-        //need to add check if the email exist or not and check if the response is 200
-        //test that the email is not alredy used
-        //maybe clean all of that because the request is huge
+    protected void sendEmail(OnRegistrationCompleteEvent event) throws MailjetSocketTimeoutException, MailjetException {
+        System.out.println("Sending email 1");
         UserModel user = event.getUser();
         String token = UUID.randomUUID().toString();
         service.createVerificationToken(user, token);
@@ -59,26 +25,9 @@ public class RegistrationListener implements ApplicationListener<OnRegistrationC
                 =  "/login/registerConfirm?token=" + token;
         String message = "Please follow the link below to verify your email address." +
                 " If your email address is not verified in 24 hours, your account will be deleted.";
-        MailjetClient client = new MailjetClient(apiKey,secretKey,new ClientOptions("v3.1"));
-        // Create a Mailjet Request with the Emailv31 resource
-        MailjetRequest request = new MailjetRequest(Emailv31.resource)
-                .property(Emailv31.MESSAGES, new JSONArray()
-                        .put(new JSONObject()
-                                .put(Emailv31.Message.FROM, new JSONObject()
-                                        .put("Email", senderEmail)
-                                        .put("Name", "Do not reply"))
-                                .put(Emailv31.Message.TO, new JSONArray()
-                                        .put(new JSONObject()
-                                                .put("Email", user.getEmail())
-                                                .put("Name", "Do not reply")))
-                                .put(Emailv31.Message.SUBJECT, "Confirm your Yaki account")
-                                .put(Emailv31.Message.TEXTPART, "Yaki")
-                                .put(Emailv31.Message.HTMLPART, "<html><body>" + message + "<br><a href=" + apiUrl + confirmationUrl + ">Confirm Registration</a></body></html>")
-                                .put(Emailv31.Message.CUSTOMID, "RegisterTest")));
-        //in case we are not in test env, don't send the email
-        if(!apiKey.equals("key") ) {
-            MailjetResponse response = client.post(request);
-        }
-
+        String subject = "Confirm your Yaki account";
+        String html = "<html><body>" + message + "<br><a href=" + apiUrl + confirmationUrl + ">Confirm Registration</a></body></html>";
+        String customId = "Register";
+        this.setSenderEmail(user.getEmail(), subject,html,customId);
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
@@ -1,0 +1,24 @@
+package com.xpeho.yaki_admin_backend.listeners;
+
+import com.mailjet.client.errors.MailjetException;
+import com.mailjet.client.errors.MailjetSocketTimeoutException;
+import com.xpeho.yaki_admin_backend.data.models.UserModel;
+import com.xpeho.yaki_admin_backend.events.OnResetPasswordCompletEvent;
+import org.springframework.stereotype.Component;
+
+
+
+@Component
+public class ResetPasswordListener extends EmailListener<OnResetPasswordCompletEvent>{
+    @Override
+    protected void sendEmail(OnResetPasswordCompletEvent event) throws MailjetSocketTimeoutException, MailjetException {
+        System.out.println("Sending email 2");
+        UserModel user = event.getUser();
+        String password = event.getPassword();
+        String message = "Your password has been reset. Your new temporary password is: " + password + ". Please change your password after logging in.";
+        String subject = "Your Yaki password has been reset";
+        String html = "<html><body>" + message + "</body></html>";
+        String customId = "Reset your password";
+        this.setSenderEmail(user.getEmail(), subject,html,customId);
+    }
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 public class ResetPasswordListener extends EmailListener<OnResetPasswordCompletEvent>{
     @Override
     protected void sendEmail(OnResetPasswordCompletEvent event) throws MailjetSocketTimeoutException, MailjetException {
-        System.out.println("Sending email 2");
         UserModel user = event.getUser();
         String password = event.getPassword();
         String divStyle = "<div style=\"font-size:16px\">";

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/listeners/ResetPasswordListener.java
@@ -15,7 +15,20 @@ public class ResetPasswordListener extends EmailListener<OnResetPasswordCompletE
         System.out.println("Sending email 2");
         UserModel user = event.getUser();
         String password = event.getPassword();
-        String message = "Your password has been reset. Your new temporary password is: " + password + ". Please change your password after logging in.";
+        String divStyle = "<div style=\"font-size:16px\">";
+        String htmlDivPassword = """
+        <div style=\"background:#faf9fa;border:1px solid #dad8de;text-align:center;
+        margin:0.5rem 0;font-size:24px;line-height:1.5;
+        width : min(90%,20rem);\">""";
+        String endDiv = "</div>";
+        String message = divStyle.concat("Your password has been reset. Your new temporary password is: ")
+                .concat(endDiv)
+                .concat(htmlDivPassword)
+                .concat(password)
+                .concat(endDiv)
+                .concat(divStyle)
+                .concat("Please change your password after logging in.")
+                .concat(endDiv);
         String subject = "Your Yaki password has been reset";
         String html = "<html><body>" + message + "</body></html>";
         String customId = "Reset your password";

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/AuthenticationController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/AuthenticationController.java
@@ -35,8 +35,8 @@ public class AuthenticationController {
     public String confirmRegister(@RequestParam("token") String token) {
         return authenticationService.confirmRegister(token);
     }
-    @PostMapping("/forgotPassword")
-    public String forgotPassword(@RequestParam("email") String email){
-        return authenticationService.forgotPassword(email);
+    @PostMapping("/forgot-password")
+    public void forgotPassword(@RequestParam("email") String email){
+        authenticationService.forgotPassword(email);
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/AuthenticationController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/AuthenticationController.java
@@ -35,4 +35,8 @@ public class AuthenticationController {
     public String confirmRegister(@RequestParam("token") String token) {
         return authenticationService.confirmRegister(token);
     }
+    @PostMapping("/forgotPassword")
+    public String forgotPassword(@RequestParam("email") String email){
+        return authenticationService.forgotPassword(email);
+    }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
@@ -37,11 +37,11 @@ public class UserController {
     }
 
     //route avalaible on the mail to reset your password
-    @GetMapping("/changePassword")
-    public String showChangePasswordPage(@RequestParam String email,
+    @PutMapping("/changePassword")
+    public void showChangePasswordPage(@RequestParam int id,
                                          @RequestParam String oldPassword,
                                          @RequestParam String newPassword) {
-        return userService.changePassword(email, oldPassword, newPassword);
+        userService.changePassword(id, oldPassword, newPassword);
     }
 
     //route when the form to change your password is submitted

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
@@ -36,15 +36,12 @@ public class UserController {
         return userService.deleteById(id);
     }
 
-    //route avalaible on the mail to reset your password
-    @PutMapping("/changePassword")
-    public void showChangePasswordPage(@RequestParam int id,
+    //route avalaible on the change your password
+    @PutMapping("/change-password")
+    public void changePassword(@RequestParam int id,
                                          @RequestParam String oldPassword,
                                          @RequestParam String newPassword) {
         userService.changePassword(id, oldPassword, newPassword);
     }
-
-    //route when the form to change your password is submitted
-
 
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
@@ -35,4 +35,16 @@ public class UserController {
     public UserEntity deleteUser(@PathVariable int id) {
         return userService.deleteById(id);
     }
+
+    //route avalaible on the mail to reset your password
+    @GetMapping("/changePassword")
+    public String showChangePasswordPage(@RequestParam String email,
+                                         @RequestParam String oldPassword,
+                                         @RequestParam String newPassword) {
+        return userService.changePassword(email, oldPassword, newPassword);
+    }
+
+    //route when the form to change your password is submitted
+
+
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImplTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -45,14 +46,14 @@ public class AuthenticationServiceImplTest {
     @Mock
     private CustomerServiceImpl customerService;
     @Mock
-    private UserServiceImpl userServiceImpl;
+    private UserServiceImpl userService;
 
     @BeforeEach
     void setUp() {
         repository = mock(UserJpaRepository.class);
 
         authenticationServiceImpl = new AuthenticationServiceImpl(repository, jwtService, authenticationManager,
-                passwordEncoder,verificationTokenService,eventPublisher,captainService,customerService, userServiceImpl );
+                passwordEncoder,verificationTokenService,eventPublisher,captainService,customerService, userService );
     }
 
     @Test
@@ -109,4 +110,13 @@ public class AuthenticationServiceImplTest {
         assertEquals(user.getUserId(), response.id());
     }
 
+    @Test
+    void testForgotPassword() {
+        // Mock input
+        String email = "email1";
+        UserModel userReturned = new UserModel("Vache", "Quirit", "email1", "email1", "encodedPassword");
+        when(repository.findByLogin(email)).thenReturn(Optional.of(userReturned));
+        doNothing().when(userService).resetPassword(userReturned,passwordEncoder);
+        assertDoesNotThrow(() -> authenticationServiceImpl.forgotPassword(email));
+    }
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/AuthenticationServiceImplTest.java
@@ -44,13 +44,15 @@ public class AuthenticationServiceImplTest {
     private CaptainServiceImpl captainService;
     @Mock
     private CustomerServiceImpl customerService;
+    @Mock
+    private UserServiceImpl userServiceImpl;
 
     @BeforeEach
     void setUp() {
         repository = mock(UserJpaRepository.class);
 
         authenticationServiceImpl = new AuthenticationServiceImpl(repository, jwtService, authenticationManager,
-                passwordEncoder,verificationTokenService,eventPublisher,captainService,customerService);
+                passwordEncoder,verificationTokenService,eventPublisher,captainService,customerService, userServiceImpl );
     }
 
     @Test
@@ -106,4 +108,5 @@ public class AuthenticationServiceImplTest {
         assertEquals(jwtToken, response.token());
         assertEquals(user.getUserId(), response.id());
     }
+
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImplTest.java
@@ -1,13 +1,13 @@
 package com.xpeho.yaki_admin_backend.data.services;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/*@ExtendWith(MockitoExtension.class)
+@ExtendWith(MockitoExtension.class)
 class PasswordServiceImplTest {
     @InjectMocks
     PasswordServiceImpl passwordService;
@@ -32,10 +32,9 @@ class PasswordServiceImplTest {
                 upperCaseCount++;
             }
         }
-        System.out.println("Password generated using commons-text: " + password);
         assertThat( lowerCaseCount >= 2);
         assertThat( upperCaseCount >= 2);
         assertThat( specialCharCount >= 2);
         assertThat(numberCount  >= 2);
     }
-}*/
+}

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/PasswordServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.xpeho.yaki_admin_backend.data.services;
+
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*@ExtendWith(MockitoExtension.class)
+class PasswordServiceImplTest {
+    @InjectMocks
+    PasswordServiceImpl passwordService;
+    @Test
+    public void whenPasswordGeneratedUsingCommonsText_thenSuccessful() {
+        String password = passwordService.generatePassword(12);
+        int lowerCaseCount = 0;
+        int upperCaseCount = 0;
+        int specialCharCount = 0;
+        int numberCount = 0;
+        for (char c : password.toCharArray()) {
+            if (c >= 97 || c <= 122) {
+                lowerCaseCount++;
+            } else if (c >= 33 || c <= 45) {
+                // Special characters
+                specialCharCount++;
+            } else if (c >= 48 || c <= 57) {
+                // Numbers
+                numberCount++;
+            } else if (c >= 65 || c <= 90) {
+                // Upper case
+                upperCaseCount++;
+            }
+        }
+        System.out.println("Password generated using commons-text: " + password);
+        assertThat( lowerCaseCount >= 2);
+        assertThat( upperCaseCount >= 2);
+        assertThat( specialCharCount >= 2);
+        assertThat(numberCount  >= 2);
+    }
+}*/


### PR DESCRIPTION
# Description
Two new route in order to reset the password given a certain email, this route will autogeerate the password and send the password by mail
The other one is used to change the password once you're already logged in, It accept the userId, the old password and the new one.

# Linked Issues
#619 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [X] Manually
- [X] Automated tests
- [ ] QA
- [ ] Other

# Additional information
I tested it with a unit test to test the generation of the password, then manually with thoses specific steps in postman:
1) By creating an account with the register route
2) Validate my account
3) Reset the password of my account
4) Go to my email address, verify that the email is send correctly
5) Copy the password given in the mail
6) Authenticate with my new credentials.
7) Use the route change password
8) Fill with my userId, my current password and the new password I want and fill the header with the Authorization necessary
9) Verify that the request send a 200 response
10) Try to authenticate with my new password.
