### PR TITLE
fix(patch_team_page): split page in widgets, review listView

### DIFF
--- a/yaki_mobile/lib/presentation/features/team_selection/team_selection.dart
+++ b/yaki_mobile/lib/presentation/features/team_selection/team_selection.dart
@@ -1,24 +1,14 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
-import 'package:yaki/data/models/team_model.dart';
-import 'package:yaki/presentation/state/providers/team_future_provider.dart';
+import 'package:yaki/presentation/features/team_selection/view/team_selection_header.dart';
+import 'package:yaki/presentation/features/team_selection/view/team_selection_list.dart';
 import 'package:yaki/presentation/state/providers/team_provider.dart';
-import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki_ui/yaki_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class TeamSelection extends ConsumerWidget {
   const TeamSelection({super.key});
-
-  void onSelection({
-    required ref,
-    required bool isSelected,
-    required TeamModel team,
-  }) {
-    ref.read(teamProvider.notifier).setSelectedTeamList(team, isSelected);
-  }
 
   void onValidationTap({
     required WidgetRef ref,
@@ -30,18 +20,14 @@ class TeamSelection extends ConsumerWidget {
     if (isButtonActivated) {
       if (selectCount == 1) {
         context.go("/declaration");
-      } else {
-        context.go("/timeSelection");
+      } else if (selectCount == 2) {
+        context.go("/morningDeclaration");
       }
     }
-    context.go("/declaration");
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final teamListAsync = ref.watch(teamFutureProvider);
-    final toDayDate = DateFormat('d MMMM y').format(DateTime.now());
-
     bool isValidationButtonEnabled =
         ref.watch(teamProvider).isValidationActivated;
 
@@ -52,54 +38,8 @@ class TeamSelection extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Padding(
-                padding: const EdgeInsets.only(left: 12.0, bottom: 35),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      toDayDate.toString(),
-                      style: textStylePageDate(),
-                    ),
-                    const SizedBox(height: 20),
-                    Text(
-                      tr('teamSelectionPageTitle1'),
-                      style: textStylePageTitle(),
-                    ),
-                    Text(
-                      tr('teamSelectionPageTitle2'),
-                      style: textStylePageTitle(),
-                    ),
-                    const SizedBox(height: 15),
-                    Text(
-                      tr('teamSelectionPageHint'),
-                      style: textStylePageHint(),
-                    ),
-                  ],
-                ),
-              ),
-              asyncTeamListDisplay(teamListAsync, onSelection, ref),
-              TeamSelectionCard(
-                picture: CircleAvatar(
-                  backgroundColor: Colors.transparent,
-                  radius: 40,
-                  child: SvgPicture.asset('assets/images/vacation.svg'),
-                ),
-                title: tr('vacation'),
-                subtitle: tr('vacation'),
-                onSelectionChanged: (bool selected) {
-                  onSelection(
-                    ref: ref,
-                    isSelected: selected,
-                    team: TeamModel(
-                      teamId: -1,
-                      teamName: "Away",
-                      teamActifFlag: true,
-                    ),
-                  );
-                },
-              ),
-              const Spacer(),
+              const TeamSelectionHeader(),
+              const TeamSelectionList(),
               Button(
                 text: tr('buttonNext'),
                 onPressed: () => onValidationTap(
@@ -117,47 +57,4 @@ class TeamSelection extends ConsumerWidget {
       ),
     );
   }
-}
-
-Widget asyncTeamListDisplay(
-  AsyncValue<List<TeamModel>> teamListAsync,
-  Function onSelection,
-  WidgetRef ref,
-) {
-  return teamListAsync.when(
-    data: (teamList) {
-      return ListView.builder(
-        shrinkWrap: true,
-        itemCount: teamList.length,
-        itemBuilder: (context, index) {
-          return Padding(
-            padding: const EdgeInsets.fromLTRB(0, 0, 0, 10),
-            child: TeamSelectionCard(
-              picture: CircleAvatar(
-                backgroundColor: Colors.transparent,
-                radius: 40,
-                child: SvgPicture.asset(
-                  'assets/images/onSite.svg',
-                ),
-              ),
-              title: 'Project',
-              subtitle: teamList[index].teamName ?? 'No team name',
-              onSelectionChanged: (bool selected) {
-                final teamId = teamList[index].teamId;
-                if (teamId != null) {
-                  onSelection(
-                    ref: ref,
-                    isSelected: selected,
-                    team: teamList[index],
-                  );
-                }
-              },
-            ),
-          );
-        },
-      );
-    },
-    error: (error, stackTrace) => const Text(""),
-    loading: () => const Text(""),
-  );
 }

--- a/yaki_mobile/lib/presentation/features/team_selection/view/team_selection_header.dart
+++ b/yaki_mobile/lib/presentation/features/team_selection/view/team_selection_header.dart
@@ -1,0 +1,39 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:yaki/presentation/styles/text_style.dart';
+
+class TeamSelectionHeader extends StatelessWidget {
+  const TeamSelectionHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final toDayDate = DateFormat('d MMMM y').format(DateTime.now());
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 12.0, bottom: 35),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            toDayDate.toString(),
+            style: textStylePageDate(),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            tr('teamSelectionPageTitle1'),
+            style: textStylePageTitle(),
+          ),
+          Text(
+            tr('teamSelectionPageTitle2'),
+            style: textStylePageTitle(),
+          ),
+          const SizedBox(height: 15),
+          Text(
+            tr('teamSelectionPageHint'),
+            style: textStylePageHint(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/yaki_mobile/lib/presentation/features/team_selection/view/team_selection_list.dart
+++ b/yaki_mobile/lib/presentation/features/team_selection/view/team_selection_list.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:yaki/data/models/team_model.dart';
+import 'package:yaki/presentation/state/providers/team_future_provider.dart';
+import 'package:yaki/presentation/state/providers/team_provider.dart';
+import 'package:yaki_ui/team_selection_card.dart';
+
+class TeamSelectionList extends ConsumerWidget {
+  const TeamSelectionList({super.key});
+
+  void onSelection({
+    required ref,
+    required bool isSelected,
+    required TeamModel team,
+  }) {
+    ref.read(teamProvider.notifier).setSelectedTeamList(team, isSelected);
+  }
+
+  //temporary : TeamModel should contain a pictoLink
+  String pictoLink(TeamModel team) {
+    final picto = team.teamName == "Absence"
+        ? 'assets/images/vacation.svg'
+        : 'assets/images/onSite.svg';
+    return picto;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final teamListAsync = ref.watch(teamFutureProvider);
+    return teamListAsync.when(
+      data: (teamList) {
+        return Expanded(
+          child: ListView.builder(
+            itemCount: teamList.length,
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: const EdgeInsets.fromLTRB(0, 0, 0, 10),
+                child: TeamSelectionCard(
+                  picture: CircleAvatar(
+                    backgroundColor: Colors.transparent,
+                    radius: 40,
+                    child: SvgPicture.asset(
+                      pictoLink(teamList[index]),
+                    ),
+                  ),
+                  title: 'Project',
+                  subtitle: teamList[index].teamName ?? 'No team name',
+                  onSelectionChanged: (bool selected) {
+                    final teamId = teamList[index].teamId;
+                    if (teamId != null) {
+                      onSelection(
+                        ref: ref,
+                        isSelected: selected,
+                        team: teamList[index],
+                      );
+                    }
+                  },
+                ),
+              );
+            },
+          ),
+        );
+      },
+      error: (error, stackTrace) => const Text(""),
+      loading: () => const Text(""),
+    );
+  }
+}

--- a/yaki_mobile/lib/presentation/state/notifiers/team_notifier.dart
+++ b/yaki_mobile/lib/presentation/state/notifiers/team_notifier.dart
@@ -41,6 +41,13 @@ class TeamNotifier extends StateNotifier<TeamPageState> {
     }
   }
 
+  void clearSelectedTeamList() {
+    state = TeamPageState(
+      selectedTeamList: [],
+      isValidationActivated: false,
+    );
+  }
+
 // DEPRECIATED (keep this function during migration)
   Future<void> fetchTeams() async {
     final teamList = await teamRepository.getTeam();

--- a/yaki_mobile/lib/presentation/state/providers/team_future_provider.dart
+++ b/yaki_mobile/lib/presentation/state/providers/team_future_provider.dart
@@ -5,7 +5,16 @@ import 'package:yaki/presentation/state/providers/team_provider.dart';
 final teamFutureProvider = FutureProvider.autoDispose<List<TeamModel>>((ref) {
   final teamRepo = ref.watch(teamRepositoryProvider);
 
-  final Future<List<TeamModel>> teamList = teamRepo.getTeam();
+  final Future<List<TeamModel>> teamList = teamRepo.getTeam().then(
+        (list) => [
+          ...list,
+          TeamModel(
+            teamId: -1,
+            teamName: "Absence",
+            teamActifFlag: true,
+          ),
+        ],
+      );
 
   return teamList;
 });


### PR DESCRIPTION
# Description
split team page selection into separate widget, making things cleaner and logic simpler
review team futur provider to directly include absence into the list

# Linked Issues
What are the issues fixed by this pull request ?
N/A

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
