### PR TITLE
fix(team_list_reset): reset team list on status page change button press

### DIFF
--- a/yaki_mobile/lib/presentation/state/notifiers/team_notifier.dart
+++ b/yaki_mobile/lib/presentation/state/notifiers/team_notifier.dart
@@ -62,6 +62,13 @@ class TeamNotifier extends StateNotifier<TeamPageState> {
     }
   }
 
+  void clearTeamList() {
+    state = TeamPageState(
+      selectedTeamList: [],
+      isButtonActivated: false,
+    );
+  }
+
 // DEPRECIATED (keep this function during migration)
   Future<void> fetchTeams() async {
     final teamList = await teamRepository.getTeam();

--- a/yaki_mobile/lib/presentation/ui/status/status_recap_fullday.dart
+++ b/yaki_mobile/lib/presentation/ui/status/status_recap_fullday.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:yaki/presentation/state/providers/status_provider.dart';
+import 'package:yaki/presentation/state/providers/team_provider.dart';
 import 'package:yaki/presentation/styles/color.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki/presentation/ui/shared/views/avatar_icon.dart';
 import 'package:yaki/presentation/ui/shared/views/circle_avatar_svg.dart';
 
-void _routeHandling(BuildContext context) {
+void _routeHandling(BuildContext context, WidgetRef ref) {
   context.go('/team-selection');
+  ref.read(teamProvider.notifier).clearTeamList();
 }
 
 class StatusRecapFullDay extends ConsumerWidget {
@@ -62,7 +64,7 @@ class StatusRecapFullDay extends ConsumerWidget {
                       height: 50,
                     ),
                     child: ElevatedButton(
-                      onPressed: () => _routeHandling(context),
+                      onPressed: () => _routeHandling(context, ref),
                       style: ElevatedButton.styleFrom(
                         elevation: 5,
                         backgroundColor: Colors.grey[400],

--- a/yaki_mobile/lib/presentation/ui/status/status_recap_halfday.dart
+++ b/yaki_mobile/lib/presentation/ui/status/status_recap_halfday.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:yaki/presentation/state/providers/halfday_status_provider.dart';
+import 'package:yaki/presentation/state/providers/team_provider.dart';
 import 'package:yaki/presentation/styles/color.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki/presentation/ui/shared/views/avatar_icon.dart';
 import 'package:yaki/presentation/ui/shared/views/circle_avatar_svg.dart';
 
-void _routeHandling(BuildContext context) {
+void _routeHandling(BuildContext context, WidgetRef ref) {
   context.go('/team-selection');
+  ref.read(teamProvider.notifier).clearTeamList();
 }
 
 class StatusRecapHalfDay extends ConsumerWidget {
@@ -87,7 +89,7 @@ class StatusRecapHalfDay extends ConsumerWidget {
                       height: 50,
                     ),
                     child: ElevatedButton(
-                      onPressed: () => _routeHandling(context),
+                      onPressed: () => _routeHandling(context, ref),
                       style: ElevatedButton.styleFrom(
                         elevation: 5,
                         backgroundColor: Colors.grey[400],

--- a/yaki_mobile/lib/presentation/ui/status/vacation_status.dart
+++ b/yaki_mobile/lib/presentation/ui/status/vacation_status.dart
@@ -2,14 +2,16 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:yaki/presentation/state/providers/team_provider.dart';
 import 'package:yaki/presentation/state/providers/vacation_status_provider.dart';
 import 'package:yaki/presentation/styles/color.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki/presentation/ui/shared/views/avatar_icon.dart';
 import 'package:yaki/presentation/ui/shared/views/circle_avatar_svg.dart';
 
-void _routeHandling(BuildContext context) {
+void _routeHandling(BuildContext context, WidgetRef ref) {
   context.go('/team-selection');
+  ref.read(teamProvider.notifier).clearTeamList();
 }
 
 void onAvatarIconPress() {}
@@ -63,7 +65,7 @@ class VacationStatus extends ConsumerWidget {
                       height: 50,
                     ),
                     child: ElevatedButton(
-                      onPressed: () => _routeHandling(context),
+                      onPressed: () => _routeHandling(context, ref),
                       style: ElevatedButton.styleFrom(
                         elevation: 5,
                         backgroundColor: Colors.grey[400],


### PR DESCRIPTION
# Description
What are changes related to ?

reset the team list when user select "change" declaration

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [ ] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
