### PR TITLE
fix(authentication): add SignleChildScroolView

### DIFF
--- a/yaki_mobile/lib/presentation/features/authentication/authentication.dart
+++ b/yaki_mobile/lib/presentation/features/authentication/authentication.dart
@@ -122,19 +122,19 @@ class _AuthenticationState extends ConsumerState<Authentication> {
         color: backgroundColor,
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.only(left: 8),
-                child: Text(
-                  tr('signInLowercase'),
-                  style: textStylePageTitle(),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: Text(
+                    tr('signInLowercase'),
+                    style: textStylePageTitle(),
+                  ),
                 ),
-              ),
-              Form(
-                child: SingleChildScrollView(
+                Form(
                   child: Column(
                     children: <Widget>[
                       Padding(
@@ -210,8 +210,8 @@ class _AuthenticationState extends ConsumerState<Authentication> {
                     ],
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
# Description

Fix the overflow  in the autenticate widget by adding a SignleChildScroolView

# Linked Issues
YAKI #837

# Changes
Fix the overflow  in the autenticate widget by adding a SignleChildScroolView


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other