### PR TITLE
refactor(declaraton): change halfday data saving, replace chip svg for constant size

### DIFF
--- a/yaki_mobile/lib/domain/entities/declaration_status.dart
+++ b/yaki_mobile/lib/domain/entities/declaration_status.dart
@@ -4,26 +4,39 @@ import 'package:yaki/presentation/displaydata/status_page_utils.dart';
 class DeclarationStatus {
   late TeamModel fullDayTeam;
   late StatusEnum fullDayStatus;
-  late DeclarationTeamsInfo teamsHalfDay = DeclarationTeamsInfo();
-  late DateTime? dateStart;
-  late DateTime? dateEnd;
+  late HalfDayWorkflow halfDayWorkflow = HalfDayWorkflow();
+  late DeclarationsHalfDaySelections declarationsHalfDaySelections;
+  late DateTime? dateAbsenceStart;
+  late DateTime? dateAbsenceEnd;
 
   DeclarationStatus();
 }
 
-const List<String> emptyDeclarationStatus = [""];
-
-class DeclarationTeamsInfo {
-  late StatusEnum firstToDSelection = StatusEnum.morning;
+class HalfDayWorkflow {
+  late StatusEnum firstToDSelection;
   late TeamModel firstTeam;
   late TeamModel secondTeam;
   late StatusEnum firstStatus;
   late StatusEnum secondStatus;
 
-  DeclarationTeamsInfo();
+  HalfDayWorkflow();
 
   @override
   String toString() {
-    return 'DeclarationTeamsInfo{firstToDSelection: $firstToDSelection, firstTeam: ${firstTeam.teamName}, secondTeam: ${secondTeam.teamName}, firstStatus: $firstStatus, secondStatus: $secondStatus}';
+    return 'HalfDayWorkflow{firstToDSelection: $firstToDSelection, firstTeam: ${firstTeam.teamName}, secondTeam: ${secondTeam.teamName}, firstStatus: $firstStatus, secondStatus: $secondStatus}';
   }
+}
+
+class DeclarationsHalfDaySelections {
+  TeamModel morningTeam;
+  StatusEnum morningTeamStatus;
+  TeamModel afternoonTeam;
+  StatusEnum afternoonTeamStatus;
+
+  DeclarationsHalfDaySelections({
+    required this.morningTeam,
+    required this.morningTeamStatus,
+    required this.afternoonTeam,
+    required this.afternoonTeamStatus,
+  });
 }

--- a/yaki_mobile/lib/presentation/displaydata/status_page_utils.dart
+++ b/yaki_mobile/lib/presentation/displaydata/status_page_utils.dart
@@ -1,5 +1,3 @@
-import 'package:yaki/domain/entities/declaration_status.dart';
-
 ///  Enum name (keys) match the json object's keys from assets/translations/*.json files format
 ///
 ///  Enum text (values) match the status format to be send to the API.
@@ -52,36 +50,5 @@ class StatusUtils {
           splited[i][0].toUpperCase() + splited[i].substring(1).toLowerCase();
     }
     return formatted;
-  }
-
-  /// Use status to create the image relative link.
-  ///
-  /// If status is an empty string the default value will be used, and display
-  /// the selected 'error' image.
-  static String getImage(String status) {
-    String link = 'assets/images/unknown.svg';
-
-    if (status != emptyDeclarationStatus.first) {
-      if (status == StatusEnum.undeclared.name) {
-        link = 'assets/images/unknown.svg';
-      } else {
-        link = 'assets/images/$status.svg';
-      }
-    }
-    return link;
-  }
-
-  /// Use status to create the translationKey value
-  ///
-  /// If status is an empty string, the translationKey for the error message will be returned.
-  static String getTranslationKey(String status, String mode) {
-    String translationKey = "StatusError";
-    String keyFormat = toCamelCase(toFormat: status);
-
-    if (status != emptyDeclarationStatus.first) {
-      keyFormat = keyFormat[0].toUpperCase() + keyFormat.substring(1);
-      translationKey = "status$keyFormat$mode";
-    }
-    return translationKey;
   }
 }

--- a/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_half_day_choice.dart
+++ b/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_half_day_choice.dart
@@ -1,10 +1,10 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:yaki/domain/entities/chip_content.dart';
 import 'package:yaki/presentation/displaydata/declaration_enum.dart';
 import 'package:yaki/presentation/displaydata/status_page_utils.dart';
+import 'package:yaki/presentation/features/shared/chip_svg_picture.dart';
 import 'package:yaki/presentation/state/providers/declaration_provider.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki_ui/icon_chip.dart';
@@ -23,8 +23,21 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final StatusEnum selectedTimeOfDay =
+        ref.read(declarationProvider).halfDayWorkflow.firstToDSelection;
+
+    final String teamName = setTeam(
+      teamList: teamNameList,
+      declarationMode: declarationMode,
+    );
+
+    final String headerText = setHeaderText(
+      selectedTimeOfDay: selectedTimeOfDay,
+      declarationMode: declarationMode,
+    );
+
     final ChipContent chipContent = setChipContent(
-      ref: ref,
+      selectedTimeOfDay: selectedTimeOfDay,
       declarationMode: declarationMode,
     );
 
@@ -42,17 +55,12 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
               style: textStylePageTitle(),
             ),
             IconChip(
-              label: setTeam(
-                teamList: teamNameList,
-                declarationMode: declarationMode,
-              ),
+              label: teamName,
               backgroundColor: Colors.white,
               image: ClipRRect(
                 borderRadius: BorderRadius.circular(50),
-                child: SvgPicture.asset(
-                  'assets/images/onSite.svg',
-                  width: 40,
-                  height: 40,
+                child: declarationChipSvgPicture(
+                  imageSrc: 'assets/images/onSite.svg',
                 ),
               ),
             ),
@@ -61,7 +69,7 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
         Row(
           children: [
             Text(
-              tr(setHeaderText(ref, declarationMode)),
+              tr(headerText),
               style: textStylePageTitle(),
             ),
             IconChip(
@@ -69,10 +77,8 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
               backgroundColor: Colors.white,
               image: ClipRRect(
                 borderRadius: BorderRadius.circular(50),
-                child: SvgPicture.asset(
-                  chipContent.imageSrc,
-                  width: 40,
-                  height: 40,
+                child: declarationChipSvgPicture(
+                  imageSrc: chipContent.imageSrc,
                 ),
               ),
             ),
@@ -100,9 +106,10 @@ String setTeam({
           : "";
 }
 
-String setHeaderText(WidgetRef ref, String declarationMode) {
-  final selectedTimeOfDay =
-      ref.watch(declarationProvider).teamsHalfDay.firstToDSelection;
+String setHeaderText({
+  required StatusEnum selectedTimeOfDay,
+  required String declarationMode,
+}) {
   final isMorning = selectedTimeOfDay == StatusEnum.morning;
   return declarationMode == DeclarationPaths.halfDayStart.text
       ? isMorning
@@ -114,13 +121,10 @@ String setHeaderText(WidgetRef ref, String declarationMode) {
 }
 
 ChipContent setChipContent({
-  required WidgetRef ref,
+  required StatusEnum selectedTimeOfDay,
   required String declarationMode,
 }) {
-  final selectedTimeOfDay =
-      ref.watch(declarationProvider).teamsHalfDay.firstToDSelection;
   final isMorning = selectedTimeOfDay == StatusEnum.morning;
-
   return declarationMode == DeclarationPaths.halfDayStart.text
       ? isMorning
           ? ChipContent(

--- a/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_single_choice.dart
+++ b/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_single_choice.dart
@@ -1,7 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:yaki/presentation/displaydata/declaration_enum.dart';
+import 'package:yaki/presentation/features/shared/chip_svg_picture.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki_ui/icon_chip.dart';
 
@@ -50,10 +50,10 @@ class HeaderDeclarationSingleChoice extends StatelessWidget {
                     backgroundColor: Colors.white,
                     image: ClipRRect(
                       borderRadius: BorderRadius.circular(50),
-                      child: SvgPicture.asset(
-                        imageSrc == '' ? 'assets/images/onSite.svg' : imageSrc,
-                        width: 50,
-                        height: 50,
+                      child: declarationChipSvgPicture(
+                        imageSrc: imageSrc == ''
+                            ? 'assets/images/onSite.svg'
+                            : imageSrc,
                       ),
                     ),
                   ),

--- a/yaki_mobile/lib/presentation/features/declaration_summary/declaration_summary.dart
+++ b/yaki_mobile/lib/presentation/features/declaration_summary/declaration_summary.dart
@@ -91,7 +91,7 @@ Widget setSummaryWidget({
     );
   } else {
     return SummaryHalfDay(
-      halfDayTeamsInfo: declarationStatus.teamsHalfDay,
+      halfDayData: declarationStatus.declarationsHalfDaySelections,
     );
   }
 }

--- a/yaki_mobile/lib/presentation/features/declaration_summary/view/summary_chips_duo.dart
+++ b/yaki_mobile/lib/presentation/features/declaration_summary/view/summary_chips_duo.dart
@@ -1,8 +1,8 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:yaki/data/models/team_model.dart';
 import 'package:yaki/presentation/displaydata/status_page_utils.dart';
+import 'package:yaki/presentation/features/shared/chip_svg_picture.dart';
 import 'package:yaki_ui/yaki_ui.dart';
 
 class SummaryChipDuo extends StatelessWidget {
@@ -25,10 +25,8 @@ class SummaryChipDuo extends StatelessWidget {
           backgroundColor: Colors.white,
           image: ClipRRect(
             borderRadius: BorderRadius.circular(50),
-            child: SvgPicture.asset(
-              "assets/images/onSite.svg",
-              width: 40,
-              height: 40,
+            child: declarationChipSvgPicture(
+              imageSrc: "assets/images/onSite.svg",
             ),
           ),
         ),
@@ -38,10 +36,8 @@ class SummaryChipDuo extends StatelessWidget {
           backgroundColor: Colors.white,
           image: ClipRRect(
             borderRadius: BorderRadius.circular(50),
-            child: SvgPicture.asset(
-              setTimeOfDayImage(status),
-              width: 40,
-              height: 40,
+            child: declarationChipSvgPicture(
+              imageSrc: setTimeOfDayImage(status),
             ),
           ),
         ),

--- a/yaki_mobile/lib/presentation/features/declaration_summary/view/summary_half_day.dart
+++ b/yaki_mobile/lib/presentation/features/declaration_summary/view/summary_half_day.dart
@@ -1,27 +1,22 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:yaki/domain/entities/declaration_status.dart';
-import 'package:yaki/domain/entities/summary_half_day_content.dart';
 import 'package:yaki/presentation/displaydata/status_page_utils.dart';
 import 'package:yaki/presentation/features/declaration_summary/view/summary_chips_duo.dart';
+import 'package:yaki/presentation/features/shared/chip_svg_picture.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki_ui/yaki_ui.dart';
 
 class SummaryHalfDay extends StatelessWidget {
-  final DeclarationTeamsInfo halfDayTeamsInfo;
+  final DeclarationsHalfDaySelections halfDayData;
 
   const SummaryHalfDay({
     super.key,
-    required this.halfDayTeamsInfo,
+    required this.halfDayData,
   });
 
   @override
   Widget build(BuildContext context) {
-    SummaryHalfDayContent summaryHalfDayContent = setSummaryHalfDayContent(
-      halfDayTeamsInfo: halfDayTeamsInfo,
-    );
-
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
@@ -30,62 +25,40 @@ class SummaryHalfDay extends StatelessWidget {
           style: textStyleSummarySubtitle(),
         ),
         const SizedBox(height: 16),
-        summaryHalfDayContent.morningStatus == StatusEnum.absence
+        halfDayData.morningTeamStatus == StatusEnum.absence
             ? IconChip(
                 label: tr(StatusEnum.absence.name),
                 backgroundColor: Colors.white,
                 image: ClipRRect(
                   borderRadius: BorderRadius.circular(50),
-                  child: SvgPicture.asset(
-                    "assets/images/absence.svg",
-                    width: 40,
-                    height: 40,
+                  child: declarationChipSvgPicture(
+                    imageSrc: "assets/images/absence.svg",
                   ),
                 ),
               )
             : SummaryChipDuo(
-                status: summaryHalfDayContent.morningStatus,
-                team: summaryHalfDayContent.morningTeam,
+                status: halfDayData.morningTeamStatus,
+                team: halfDayData.morningTeam,
               ),
         const SizedBox(height: 36),
         Text(tr("afternoon").toUpperCase(), style: textStyleSummarySubtitle()),
         const SizedBox(height: 16),
-        summaryHalfDayContent.afternoonStatus == StatusEnum.absence
+        halfDayData.afternoonTeamStatus == StatusEnum.absence
             ? IconChip(
                 label: tr(StatusEnum.absence.name),
                 backgroundColor: Colors.white,
                 image: ClipRRect(
                   borderRadius: BorderRadius.circular(50),
-                  child: SvgPicture.asset(
-                    "assets/images/absence.svg",
-                    width: 40,
-                    height: 40,
+                  child: declarationChipSvgPicture(
+                    imageSrc: "assets/images/absence.svg",
                   ),
                 ),
               )
             : SummaryChipDuo(
-                status: summaryHalfDayContent.afternoonStatus,
-                team: summaryHalfDayContent.afternoonTeam,
+                status: halfDayData.afternoonTeamStatus,
+                team: halfDayData.afternoonTeam,
               ),
       ],
     );
   }
-}
-
-SummaryHalfDayContent setSummaryHalfDayContent({
-  required DeclarationTeamsInfo halfDayTeamsInfo,
-}) {
-  return halfDayTeamsInfo.firstToDSelection == StatusEnum.morning
-      ? SummaryHalfDayContent(
-          morningTeam: halfDayTeamsInfo.firstTeam,
-          morningStatus: halfDayTeamsInfo.firstStatus,
-          afternoonTeam: halfDayTeamsInfo.secondTeam,
-          afternoonStatus: halfDayTeamsInfo.secondStatus,
-        )
-      : SummaryHalfDayContent(
-          morningTeam: halfDayTeamsInfo.secondTeam,
-          morningStatus: halfDayTeamsInfo.secondStatus,
-          afternoonTeam: halfDayTeamsInfo.firstTeam,
-          afternoonStatus: halfDayTeamsInfo.firstStatus,
-        );
 }

--- a/yaki_mobile/lib/presentation/features/shared/chip_svg_picture.dart
+++ b/yaki_mobile/lib/presentation/features/shared/chip_svg_picture.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+Widget declarationChipSvgPicture({required String imageSrc}) {
+  return SvgPicture.asset(
+    imageSrc,
+    width: 32,
+    height: 32,
+  );
+}

--- a/yaki_mobile/lib/presentation/state/notifiers/vacation_status_notifier.dart
+++ b/yaki_mobile/lib/presentation/state/notifiers/vacation_status_notifier.dart
@@ -41,8 +41,8 @@ class VacationStatusNotifier extends StateNotifier<StateVacationPage> {
   /// And invoke the "setStateVacation" method.
   void setSelectedStatusVacation() {
     final DeclarationStatus declarationStatus = ref.read(declarationProvider);
-    DateTime? fullDateStart = declarationStatus.dateStart;
-    DateTime? fullDateEnd = declarationStatus.dateEnd;
+    DateTime? fullDateStart = declarationStatus.dateAbsenceStart;
+    DateTime? fullDateEnd = declarationStatus.dateAbsenceEnd;
     setStateVacation(fullDateStart, fullDateEnd);
   }
 }


### PR DESCRIPTION
Review halfDay selected option saving.
Created new object to determine morning and afternoon choice and save them at the end of the halfDay workflow process.

simplify halfday summary declaration page information display, and will simplify getlastest declaration process.

created function to return a svgpicture with fixed size (to match bastiUI figma) and assigne them to currently used inconChip widget.
will avoid potential incorrect image sizing and chip distortion

# Description
What are changes related to ?

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
