### PR TITLE
fix(nameValidatorRegex): change the regex

### DIFF
--- a/yaki_mobile/lib/presentation/ui/registration/form_functionality.dart
+++ b/yaki_mobile/lib/presentation/ui/registration/form_functionality.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 
 // Validators for each input
 String? nameValidator(String? value) {
-  final nameRegex = RegExp(r"^[A-Za-z ç-]+$");
+  final nameRegex = RegExp(r"^[A-Za-zÀ-ÿœŒÆæïÎî ç-]+$");
   if (value == null || value.isEmpty) {
     return tr('registrationInputNameError1');
   }

--- a/yaki_mobile/lib/presentation/ui/registration/form_functionality.dart
+++ b/yaki_mobile/lib/presentation/ui/registration/form_functionality.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 
 // Validators for each input
 String? nameValidator(String? value) {
-  final nameRegex = RegExp(r"^[A-Za-zÀ-ÿœŒÆæïÎî ç-]+$");
+  final nameRegex = RegExp(r"([A-Z][a-z]*)([\\s\\\'-][A-Z][a-z]*)*");
   if (value == null || value.isEmpty) {
     return tr('registrationInputNameError1');
   }


### PR DESCRIPTION
# Description
change the regex for the name validator to accept all french character

# Linked Issues
YAKI #885 

# Changes

This change is a fix to add character to the regex like this (r"^[A-Za-zÀ-ÿœŒÆæïÎî ç-]+$"), now the regex accept all french character

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

