### PR TITLE
fix(UI): updated yaki_ui components with proper values

### DIFF
--- a/yaki_mobile/lib/presentation/features/authentication/authentication.dart
+++ b/yaki_mobile/lib/presentation/features/authentication/authentication.dart
@@ -146,6 +146,7 @@ class _AuthenticationState extends ConsumerState<Authentication> {
                         ),
                         const SizedBox(height: 10),
                         Button(
+                          buttonHeight: 72,
                           text: tr('signIn'),
                           onPressed: () => onPressAuthent(
                             ref: ref,
@@ -161,6 +162,7 @@ class _AuthenticationState extends ConsumerState<Authentication> {
                         ),
                         const SizedBox(height: 5),
                         Button.secondary(
+                          buttonHeight: 64,
                           text: tr('forgotPassword'),
                           onPressed: () => onPressedForgotPassword(
                             goToForgotPassword: () =>

--- a/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_half_day_choice.dart
+++ b/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_half_day_choice.dart
@@ -57,6 +57,8 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
             IconChip(
               label: teamName,
               backgroundColor: Colors.white,
+              borderWidth: 2,
+              fontSizeLabel: 20,
               image: ClipRRect(
                 borderRadius: BorderRadius.circular(50),
                 child: const UserDeclarationChipSvgPicture(
@@ -75,6 +77,8 @@ class HeaderDeclarationHalfDayChoice extends ConsumerWidget {
             IconChip(
               label: tr(chipContent.label),
               backgroundColor: Colors.white,
+              borderWidth: 2,
+              fontSizeLabel: 20,
               image: ClipRRect(
                 borderRadius: BorderRadius.circular(50),
                 child: UserDeclarationChipSvgPicture(

--- a/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_single_choice.dart
+++ b/yaki_mobile/lib/presentation/features/declaration/view/header_declaration_single_choice.dart
@@ -48,6 +48,8 @@ class HeaderDeclarationSingleChoice extends StatelessWidget {
                   IconChip(
                     label: setTeam(teamList: teamNameList),
                     backgroundColor: Colors.white,
+                    borderWidth: 2,
+                    fontSizeLabel: 20,
                     image: ClipRRect(
                       borderRadius: BorderRadius.circular(50),
                       child: UserDeclarationChipSvgPicture(

--- a/yaki_mobile/lib/presentation/features/team_selection/team_selection.dart
+++ b/yaki_mobile/lib/presentation/features/team_selection/team_selection.dart
@@ -30,6 +30,7 @@ class TeamSelection extends ConsumerWidget {
               const TeamSelectionList(),
               Button(
                 text: tr('buttonNext'),
+                buttonHeight: 64,
                 onPressed: () => onValidationTap(
                   ref: ref,
                   context: context,
@@ -39,7 +40,7 @@ class TeamSelection extends ConsumerWidget {
                     ? const Color(0xFFFF936B)
                     : const Color.fromARGB(255, 195, 190, 190),
               ),
-              const SizedBox(height: 32),
+              const SizedBox(height: 16),
             ],
           ),
         ),

--- a/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_card.dart
+++ b/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_card.dart
@@ -51,6 +51,7 @@ class CellCard extends ConsumerWidget {
             ),
           if (isModifierBtnUsed)
             Button.secondary(
+              buttonHeight: 52,
               onPressed: () {
                 ref.read(teamProvider.notifier).clearTeamList();
                 context.go('/team-selection');

--- a/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_iconchips.dart
+++ b/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_iconchips.dart
@@ -31,6 +31,7 @@ class CellIconChips extends StatelessWidget {
               IconChip(
                 label: teamName,
                 backgroundColor: AppColors.cellChipDefault,
+                fontWeightLabel: FontWeight.w500,
                 image: ClipRRect(
                   borderRadius: BorderRadius.circular(50),
                   child: const CellIconChipSvgPicture(
@@ -45,6 +46,7 @@ class CellIconChips extends StatelessWidget {
             IconChip(
               label: tr(status.name),
               backgroundColor: setStatusColor(status),
+              fontWeightLabel: FontWeight.w500,
               image: ClipRRect(
                 borderRadius: BorderRadius.circular(50),
                 child: CellIconChipSvgPicture(
@@ -67,6 +69,7 @@ class CellIconChips extends StatelessWidget {
                 IconChip(
                   label: teamNameAfternoon!,
                   backgroundColor: AppColors.cellChipDefault,
+                  fontWeightLabel: FontWeight.w500,
                   image: ClipRRect(
                     borderRadius: BorderRadius.circular(50),
                     child: const CellIconChipSvgPicture(
@@ -81,6 +84,7 @@ class CellIconChips extends StatelessWidget {
               IconChip(
                 label: tr(statusAfternoon!.name),
                 backgroundColor: setStatusColor(statusAfternoon!),
+                fontWeightLabel: FontWeight.w500,
                 image: ClipRRect(
                   borderRadius: BorderRadius.circular(50),
                   child: CellIconChipSvgPicture(

--- a/yaki_mobile/lib/presentation/features/user_declaration_summary/user_declaration_summary.dart
+++ b/yaki_mobile/lib/presentation/features/user_declaration_summary/user_declaration_summary.dart
@@ -55,16 +55,17 @@ class UserDeclarationSummary extends ConsumerWidget {
                     child: setSummaryWidget(ref: ref, summaryMode: summaryMode),
                   ),
                 ),
-                Button(
+                Button.tertiary(
+                  buttonHeight: 68,
                   text: tr("modify"),
                   onPressed: () {
                     ref.read(teamProvider.notifier).clearTeamList();
                     context.go("/team-selection");
                   },
-                  color: const Color(0xFF37414C),
                 ),
                 const SizedBox(height: 8),
                 Button.secondary(
+                  buttonHeight: 68,
                   text: tr("seeTeam"),
                   onPressed: () => {
                     context.go("/teams-declaration-summary"),

--- a/yaki_mobile/lib/presentation/features/user_declaration_summary/user_declaration_summary_absence.dart
+++ b/yaki_mobile/lib/presentation/features/user_declaration_summary/user_declaration_summary_absence.dart
@@ -60,16 +60,17 @@ class UserDeclarationSummaryAbsence extends ConsumerWidget {
                     ),
                   ),
                 ),
-                Button(
+                Button.tertiary(
+                  buttonHeight: 68,
                   text: tr("modify"),
                   onPressed: () {
                     ref.read(teamProvider.notifier).clearTeamList();
                     context.go("/team-selection");
                   },
-                  color: const Color(0xFF37414C),
                 ),
                 const SizedBox(height: 8),
-                Button.secondary(
+                Button.tertiary(
+                  buttonHeight: 68,
                   text: tr("seeTeam"),
                   onPressed: () => {
                     context.go("/teams-declaration-summary"),

--- a/yaki_mobile/lib/presentation/features/user_declaration_summary/view/summary_chips_duo.dart
+++ b/yaki_mobile/lib/presentation/features/user_declaration_summary/view/summary_chips_duo.dart
@@ -23,6 +23,8 @@ class SummaryChipDuo extends StatelessWidget {
         IconChip(
           label: team.teamName,
           backgroundColor: Colors.white,
+          borderWidth: 2,
+          fontSizeLabel: 20,
           image: ClipRRect(
             borderRadius: BorderRadius.circular(50),
             child: const UserDeclarationChipSvgPicture(
@@ -34,6 +36,8 @@ class SummaryChipDuo extends StatelessWidget {
         IconChip(
           label: tr(status.name),
           backgroundColor: Colors.white,
+          borderWidth: 2,
+          fontSizeLabel: 20,
           image: ClipRRect(
             borderRadius: BorderRadius.circular(50),
             child: UserDeclarationChipSvgPicture(

--- a/yaki_mobile/pubspec.lock
+++ b/yaki_mobile/pubspec.lock
@@ -1069,11 +1069,11 @@ packages:
     dependency: "direct main"
     description:
       path: flutter
-      ref: "0.4.4"
-      resolved-ref: "91f6e919d880d48bd76bfd6d19c19840a65d03ed"
+      ref: "0.5.2"
+      resolved-ref: "10b1585c8e016cfdbe202ccb9f073c3abbe92ac7"
       url: "https://github.com/XPEHO/yaki_ui.git"
     source: git
-    version: "0.4.4"
+    version: "0.5.2"
   yaml:
     dependency: transitive
     description:

--- a/yaki_mobile/pubspec.yaml
+++ b/yaki_mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaki
 description: Open source project, with the goal of allowing employees to notify to their working team if they work remotely or on site. This app, also allow to any team lead to easyly see his coworker status on that matter.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 0.0.0+0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -51,7 +51,7 @@ dependencies:
   # import 'package:retrofit/retrofit.dart';
   # import 'package:dio/dio.dart';
   # link : https://pub.dev/packages/retrofit
-  retrofit: '>=4.0.0 <5.0.0'
+  retrofit: ">=4.0.0 <5.0.0"
   logger: ^2.0.2 #for logging purpose
 
   # easy_localization : manage app translation, use folder defined in assets "translations",
@@ -92,7 +92,7 @@ dependencies:
     git:
       url: https://github.com/XPEHO/yaki_ui.git
       path: flutter
-      ref: 0.4.4
+      ref: 0.5.2
   collection: ^1.17.2
 
 dev_dependencies:
@@ -111,7 +111,7 @@ dev_dependencies:
 
   # Retrofit dependency
   retrofit_generator: ^7.0.8
-  build_runner: '>=2.3.0 <4.0.0'
+  build_runner: ">=2.3.0 <4.0.0"
   json_serializable: ^6.7.1
 
   # Mockito 5.0.0 supports Dart's new null safety language feature in Dart 2.12, primarily
@@ -174,4 +174,4 @@ flutter_launcher_icons:
   remove_alpha_ios: true
   web:
     generate: true
-  image_path: 'assets/images/yaki_basti_icon.png'
+  image_path: "assets/images/yaki_basti_icon.png"


### PR DESCRIPTION
# Description
What are changes related to ?

Updated component from yaki_ui with necessary values to match the BastiUI figma
- button size
- iconChip with or without border, and font size.

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="459" alt="Capture d’écran 2023-10-13 à 15 20 30" src="https://github.com/XPEHO/YAKI/assets/95299697/0f269d9d-f29e-41f5-8ca4-d621f7bf7cbf">

<img width="456" alt="Capture d’écran 2023-10-13 à 15 21 44" src="https://github.com/XPEHO/YAKI/assets/95299697/6c4cbf1b-20bd-4f09-81f0-406b8a8a0be2">

<img width="418" alt="Capture d’écran 2023-10-13 à 15 21 53" src="https://github.com/XPEHO/YAKI/assets/95299697/a433c8db-07a8-463a-a05e-e354f9ade413">

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
N/A
