### PR TITLE
Feat/add back button

### DIFF
--- a/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
+++ b/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
@@ -74,6 +74,16 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.yakiPrimaryColor,
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        leading: IconButton(
+          onPressed: () {
+            context.go('/authentication');
+          },
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 30),
         child: Column(
@@ -110,7 +120,7 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
               padding: const EdgeInsets.only(top: 25),
               child: ConfirmationElevatedButton(
                 text: tr('registrationCancelButton'),
-                onPressed: () => context.go("/"),
+                onPressed: () => context.go("/authentication"),
                 foregroundColor: const Color.fromARGB(212, 183, 146, 14),
                 backgroundColor: const Color.fromARGB(255, 107, 97, 96),
                 btnTextStyle: registrationCancelTextStyle(),

--- a/yaki_mobile/lib/presentation/ui/registration/registration.dart
+++ b/yaki_mobile/lib/presentation/ui/registration/registration.dart
@@ -183,7 +183,7 @@ class _RegistrationState extends ConsumerState<Registration> {
                   padding: const EdgeInsets.only(top: 40),
                   child: ConfirmationElevatedButton(
                     text: tr('registrationCancelButton'),
-                    onPressed: () => context.go("/"),
+                    onPressed: () => context.go("/authentication"),
                     foregroundColor: const Color.fromARGB(212, 183, 146, 14),
                     backgroundColor: const Color.fromARGB(255, 107, 97, 96),
                     btnTextStyle: registrationCancelTextStyle(),


### PR DESCRIPTION
# Description
Add the back button in the app bar on the screen "forgot password"

# Linked Issues
#965 

# Changes
this is a feat, in the forgot_password.dart file, add a appbar widget with a IconButton, on press the user can back to the authentication screen 

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other
