### PR TITLE
fix(ForgotPasswordTheme):  add good button

### DIFF
--- a/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
+++ b/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
@@ -6,9 +6,9 @@ import 'package:yaki/presentation/state/providers/password_provider.dart';
 import 'package:yaki/presentation/styles/color.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki/presentation/ui/registration/view/registration_snackbar.dart';
-import 'package:yaki/presentation/ui/shared/views/confirmation_elevated_button.dart';
 import 'package:yaki/presentation/ui/shared/views/input_registration_page.dart';
 import 'package:yaki/presentation/ui/registration/form_functionality.dart';
+import 'package:yaki_ui/yaki_ui.dart';
 
 class ForgotPassword extends ConsumerStatefulWidget {
   const ForgotPassword({super.key});
@@ -106,25 +106,17 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
                 isShown: false,
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 40),
-              child: ConfirmationElevatedButton(
-                text: tr('changePasswordPageConfimButton'),
-                onPressed: forgotPasswordValidation,
-                foregroundColor: const Color.fromARGB(212, 183, 146, 14),
-                backgroundColor: const Color.fromARGB(255, 220, 219, 219),
-                btnTextStyle: registrationBtnTextStyle(),
-              ),
+            const SizedBox(height: 10),
+            Button(
+              buttonHeight: 72,
+              text: tr('changePasswordPageConfimButton').toUpperCase(),
+              onPressed: forgotPasswordValidation,
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 25),
-              child: ConfirmationElevatedButton(
-                text: tr('registrationCancelButton'),
-                onPressed: () => context.go("/authentication"),
-                foregroundColor: const Color.fromARGB(212, 183, 146, 14),
-                backgroundColor: const Color.fromARGB(255, 107, 97, 96),
-                btnTextStyle: registrationCancelTextStyle(),
-              ),
+            const SizedBox(height: 5),
+            Button.secondary(
+              buttonHeight: 64,
+              text: tr('registrationCancelButton').toUpperCase(),
+              onPressed: () => context.go("/authentication"),
             ),
           ],
         ),

--- a/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
+++ b/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
@@ -70,6 +70,8 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
 
   @override
   Widget build(BuildContext context) {
+    var size = MediaQuery.of(context).size;
+
     return Scaffold(
       backgroundColor: AppColors.yakiPrimaryColor,
       appBar: AppBar(
@@ -83,26 +85,27 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
         ),
       ),
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 30),
+        padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 40),
-              child: Text(
-                tr('resetPassword'),
-                style: registrationPageTitleTextStyle(),
-              ),
+          children: <Widget>[
+            SizedBox(height: size.height / 10),
+            Image.asset(
+              'assets/images/yaki_basti_icon.png',
+              height: 100,
+              width: 100,
             ),
+            SizedBox(height: size.height / 20),
+            Text(
+              tr('resetPassword'),
+              style: textStylePageTitle(),
+            ),
+            const SizedBox(height: 20),
             Form(
               key: _formKey,
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: InputText(
-                  type: InputTextType.password,
-                  controller: emailController,
-                  label: tr('inputLogin'),
-                ),
+              child: InputText(
+                type: InputTextType.email,
+                controller: emailController,
+                label: tr('inputLogin'),
               ),
             ),
             const SizedBox(height: 10),

--- a/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
+++ b/yaki_mobile/lib/presentation/ui/password/forgot_password.dart
@@ -6,8 +6,6 @@ import 'package:yaki/presentation/state/providers/password_provider.dart';
 import 'package:yaki/presentation/styles/color.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 import 'package:yaki/presentation/ui/registration/view/registration_snackbar.dart';
-import 'package:yaki/presentation/ui/shared/views/input_registration_page.dart';
-import 'package:yaki/presentation/ui/registration/form_functionality.dart';
 import 'package:yaki_ui/yaki_ui.dart';
 
 class ForgotPassword extends ConsumerStatefulWidget {
@@ -98,12 +96,13 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
             ),
             Form(
               key: _formKey,
-              child: InputRegistration(
-                textInputAction: TextInputAction.done,
-                controller: emailController,
-                label: tr('registrationInputEmailLabel'),
-                validatorFunction: emailValidator,
-                isShown: false,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: InputText(
+                  type: InputTextType.password,
+                  controller: emailController,
+                  label: tr('inputLogin'),
+                ),
               ),
             ),
             const SizedBox(height: 10),


### PR DESCRIPTION
# Description
Forgot password screen hasn't a good theme yet.

# Linked Issues
#961 

# Changes
this is a fix, in the forgot_password.dart file add the good button with the yaki_UI package

# Screenshots
![image](https://github.com/XPEHO/YAKI/assets/92584130/add8e727-2948-47e5-ba5e-52492a7fa611)# Tests

How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
