### PR TITLE
fix(back_mobile): the teammates summary page can display undeclared while its not

### DIFF
--- a/yaki_backend/src/features/declaration/declaration.repository.ts
+++ b/yaki_backend/src/features/declaration/declaration.repository.ts
@@ -35,8 +35,13 @@ export class DeclarationRepository {
       declaration_is_latest
     ) 
     VALUES ($1, $2, $3, $4, $5, $6, ${isLatest}) RETURNING *`;
+
     try {
       const result = await client.query(query, declarationValuesList);
+      // make sure current day declaration is correctly tagged as true
+      if (isLatest === true && result.rows[0].declaration_is_latest === false) {
+        throw new TypeError("Error while creating declaration");
+      }
       const declarationToFront = [
         new DeclarationDtoIn(
           result.rows[0].declaration_id,
@@ -86,6 +91,13 @@ export class DeclarationRepository {
         VALUES ($1, $2, $3, $4, $5, $6, ${isLatest}), ($7, $8, $9, $10, $11, $12, ${isLatest}) RETURNING *`,
         declarationsValuesList
       );
+
+      // make sure both current half day declaration are correctly tagged as true
+      for (let declaration of result.rows) {
+        if (isLatest === true && declaration.declaration_is_latest === false) {
+          throw new TypeError("Error while creating declaration");
+        }
+      }
 
       const declarationListToFront = result.rows.map((item) => {
         return new DeclarationDtoIn(

--- a/yaki_backend/src/features/declaration/declaration.service.ts
+++ b/yaki_backend/src/features/declaration/declaration.service.ts
@@ -51,7 +51,7 @@ export class DeclarationService {
       // an absence created for the current day will be considered as the latest declaration
       if (dateStart.getTime() === dateEnd.getTime() && dateStart.getTime() === today.getTime()) {
         // unflag from true to false the preview "latest" declaration
-        this.declarationRepository.unflagLatestDeclaration(declarationList[0].declarationUserId);
+        await this.declarationRepository.unflagLatestDeclaration(declarationList[0].declarationUserId);
 
         return await this.declarationRepository.createDeclaration(declarationList, true);
       }
@@ -112,7 +112,7 @@ export class DeclarationService {
     }
     if (isObjectsValid) {
       // unflag from true to false the preview "latest" declaration
-      this.declarationRepository.unflagLatestDeclaration(declarationList[0].declarationUserId);
+      await this.declarationRepository.unflagLatestDeclaration(declarationList[0].declarationUserId);
 
       return await this.declarationRepository.createHalfDayDeclaration(declarationList, true);
     } else {


### PR DESCRIPTION
# Description
What are changes related to ?

could create a bug where user would see his declaration as undeclared while he juste had created his declaration

# Linked Issues
What are the issues fixed by this pull request ?
#974 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
