### PR TITLE
feat(back_picture): do not save default avatar in the database

### DIFF
--- a/yaki_backend/src/features/user/userInformations.dto.ts
+++ b/yaki_backend/src/features/user/userInformations.dto.ts
@@ -1,0 +1,14 @@
+import {AvatarEnum} from "./avatar.enum";
+export class UserInformationDto {
+  userLastname: string;
+  userFirstname: string;
+  userEmail: string;
+  userAvatarChoice: AvatarEnum;
+
+  constructor(userLastname: string, userFirstname: string, userEmail: string, userAvatarChoice: AvatarEnum) {
+    this.userLastname = userLastname;
+    this.userFirstname = userFirstname;
+    this.userEmail = userEmail;
+    this.userAvatarChoice = userAvatarChoice;
+  }
+}

--- a/yaki_backend/src/router.ts
+++ b/yaki_backend/src/router.ts
@@ -55,9 +55,17 @@ router.get("/users/:userId", (req, res) => {
   userController.getUserById(req, res);
 });
 
-//"avatar" is the field of the form being sent from the front
-router.post("/users/:id/avatar-selection", upload.single("avatar"), (req, res) =>
-  userController.registerNewAvatar(req, res)
+router.post(
+  "/users/:id/avatar-selection",
+  upload.single("avatar"),
+  (req, res, next) => authService.verifyToken(req, res, next),
+  async (req, res) => userController.registerNewAvatar(req, res)
+);
+
+router.get(
+  "/users/:id/personal-avatar",
+  (req, res, next) => authService.verifyToken(req, res, next),
+  async (req, res) => userController.getPersonalAvatarByUserId(req, res)
 );
 
 // DEPRECIATED - TO BE REMOVED WHEN 1.10 isnt used anymore

--- a/yaki_backend/src/utils/PictureProcessing.ts
+++ b/yaki_backend/src/utils/PictureProcessing.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import * as path from "path";
+
+export default class PictureProcessing {
+  /**
+   * Convert a bytea to a picture file.
+   * It will either be a svg or a jpg file, depending of the avatar reference.
+   * @param avatarData
+   * @returns
+   */
+  static byteaToImage = (avatar: Buffer) => {
+    // Convert byte array to Buffer
+    const buffer = Buffer.from(avatar);
+    // Write Buffer to file
+    const filePath = path.join(__dirname, `avatar.jpg"}`);
+    fs.writeFileSync(filePath, buffer);
+    return filePath;
+  };
+
+  /**
+   * Delete a file upload by Multer once the necessary process is done
+   * @param file
+   */
+  static deleteUploadedFile = (file: any) => {
+    fs.unlink(file.path, (err) => {
+      if (err) {
+        console.error("Error deleting file:", err);
+      }
+    });
+  };
+}

--- a/yaki_backend/src/utils/yakiUtils.ts
+++ b/yaki_backend/src/utils/yakiUtils.ts
@@ -1,8 +1,3 @@
-import {AvatarDto} from "../features/user/avatar.dto";
-import {AvatarEnum} from "../features/user/avatar.enum";
-import fs from "fs";
-import * as path from "path";
-
 export default class YakiUtils {
   /**
    * Transform a object list into a flat array containing only the objects values.
@@ -74,26 +69,4 @@ export default class YakiUtils {
 
     return todayNoTime;
   }
-
-  /**
-   * Convert a bytea to a picture file.
-   * It will either be a svg or a jpg file, depending of the avatar reference.
-   * @param avatarData
-   * @returns
-   */
-  static byteaToPicture = (avatarData: AvatarDto) => {
-    let fileExtension;
-    if (avatarData.avatarReference !== AvatarEnum.USERPICTURE) {
-      fileExtension = ".svg";
-    } else if (avatarData.avatarReference === AvatarEnum.USERPICTURE) {
-      fileExtension = ".jpg";
-    }
-
-    // Convert byte array to Buffer
-    const buffer = Buffer.from(avatarData.avatarBlob);
-    // Write Buffer to file
-    const filePath = path.join(__dirname, `avatar${fileExtension}`);
-    fs.writeFileSync(filePath, buffer);
-    return filePath;
-  };
 }


### PR DESCRIPTION
# Description
What are changes related to ?
Update the process of registering user avatar selection in the database.
Will not register the default avatar (the ones from the applications)
but will register and save the avartar selected by the user.

# Linked Issues
What are the issues fixed by this pull request ?
#808 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
