### PR TITLE
fix(TeamDeclarationSummaryPadding): add bottom pad

### DIFF
--- a/yaki_mobile/lib/presentation/features/teams_declarations_summary/teams_declarations_summary.dart
+++ b/yaki_mobile/lib/presentation/features/teams_declarations_summary/teams_declarations_summary.dart
@@ -61,7 +61,7 @@ class TeamsDeclarationSummary extends ConsumerWidget {
       ),
       body: const SafeArea(
         child: Padding(
-          padding: EdgeInsets.only(left: 16, right: 16),
+          padding: EdgeInsets.only(left: 16, right: 16, bottom: 24),
           child: TeammateListAsync(),
         ),
       ),


### PR DESCRIPTION
# Description

Add a bottom padding in the team_declaration_summary to create space between the last cell card and the bottom of the screen

# Linked Issues
#1029 

# Changes
it's just a fix by adding a padding bottom 

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
