### PR TITLE
feat(App_bar_date): add conditionnal rendering

### DIFF
--- a/yaki_mobile/lib/domain/entities/declaration_status.dart
+++ b/yaki_mobile/lib/domain/entities/declaration_status.dart
@@ -2,6 +2,7 @@ import 'package:yaki/data/models/team_model.dart';
 import 'package:yaki/presentation/displaydata/declaration_status_enum.dart';
 
 class DeclarationStatus {
+  late bool isAlreadyDeclared = false;
   late TeamModel fullDayTeam = defaultTeam;
   late StatusEnum fullDayStatus = StatusEnum.undeclared;
   late HalfDayWorkflow halfDayWorkflow = HalfDayWorkflow();
@@ -13,6 +14,7 @@ class DeclarationStatus {
   DeclarationStatus();
 
   DeclarationStatus copyWith({
+    bool? isAlreadyDeclared,
     TeamModel? fullDayTeam,
     StatusEnum? fullDayStatus,
     HalfDayWorkflow? halfDayWorkflow,
@@ -23,6 +25,7 @@ class DeclarationStatus {
     bool? isfullDay,
   }) {
     return DeclarationStatus()
+      ..isAlreadyDeclared = isAlreadyDeclared ?? this.isAlreadyDeclared
       ..fullDayTeam = fullDayTeam ?? this.fullDayTeam
       ..fullDayStatus = fullDayStatus ?? this.fullDayStatus
       ..halfDayWorkflow = halfDayWorkflow ?? this.halfDayWorkflow

--- a/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
+++ b/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
@@ -16,41 +16,40 @@ class AppBarWithDate extends ConsumerWidget implements PreferredSizeWidget {
     final currentRoute = ModalRoute.of(context)?.settings.name;
     final showBackButton = currentRoute == 'team-selection';
 
-    Future<bool> getIsDeclared() async {
-      return await ref
-          .read(declarationProvider.notifier)
-          .getLatestDeclaration();
-    }
+    final isAlreadyDeclared = ref.watch(declarationProvider).isAlreadyDeclared;
+    print(isAlreadyDeclared);
+    // Future<bool> getIsDeclared() async {
+    //   return await ref
+    //       .read(declarationProvider.notifier)
+    //       .getLatestDeclaration();
+    // }
 
-    return FutureBuilder<bool>(
-      future: getIsDeclared(),
-      builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const CircularProgressIndicator(); // or some other widget while waiting for data
-        } else {
-          final isDeclared = snapshot.data ?? false;
-          return AppBar(
-            centerTitle: false,
-            automaticallyImplyLeading: showBackButton && isDeclared,
-            leading: showBackButton && isDeclared
-                ? IconButton(
-                    icon: const Icon(Icons.arrow_back),
-                    onPressed: () => context.go('/teams-declaration-summary'),
-                  )
-                : null,
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            title: Padding(
-              padding: const EdgeInsets.only(left: 16),
-              child: Text(
-                toDayDate,
-                style: textStylePageDate(),
-              ),
-            ),
-            actions: actions,
-          );
-        }
-      },
+    // return FutureBuilder<bool>(
+    //   future: getIsDeclared(),
+    //   builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+    //     if (snapshot.connectionState == ConnectionState.waiting) {
+    //       return const CircularProgressIndicator(); // or some other widget while waiting for data
+    //     } else {
+    //       final isDeclared = snapshot.data ?? false;
+    return AppBar(
+      centerTitle: false,
+      automaticallyImplyLeading: showBackButton && isAlreadyDeclared,
+      leading: showBackButton && isAlreadyDeclared
+          ? IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.go('/teams-declaration-summary'),
+            )
+          : null,
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      title: Padding(
+        padding: const EdgeInsets.only(left: 16),
+        child: Text(
+          toDayDate,
+          style: textStylePageDate(),
+        ),
+      ),
+      actions: actions,
     );
   }
 

--- a/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
+++ b/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
@@ -1,29 +1,56 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yaki/presentation/state/providers/declaration_provider.dart';
 import 'package:yaki/presentation/styles/text_style.dart';
 
-class AppBarWithDate extends StatelessWidget implements PreferredSizeWidget {
+class AppBarWithDate extends ConsumerWidget implements PreferredSizeWidget {
   final List<Widget>? actions;
 
-  const AppBarWithDate({super.key, this.actions});
+  const AppBarWithDate({Key? key, this.actions}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final toDayDate = DateFormat('d MMMM y').format(DateTime.now());
+    final currentRoute = ModalRoute.of(context)?.settings.name;
+    final showBackButton = currentRoute == 'team-selection';
 
-    return AppBar(
-      centerTitle: false,
-      automaticallyImplyLeading: false,
-      backgroundColor: Colors.transparent,
-      elevation: 0,
-      title: Padding(
-        padding: const EdgeInsets.only(left: 16),
-        child: Text(
-          toDayDate,
-          style: textStylePageDate(),
-        ),
-      ),
-      actions: actions,
+    Future<bool> getIsDeclared() async {
+      return await ref
+          .read(declarationProvider.notifier)
+          .getLatestDeclaration();
+    }
+
+    return FutureBuilder<bool>(
+      future: getIsDeclared(),
+      builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const CircularProgressIndicator(); // or some other widget while waiting for data
+        } else {
+          final isDeclared = snapshot.data ?? false;
+          return AppBar(
+            centerTitle: false,
+            automaticallyImplyLeading: showBackButton && isDeclared,
+            leading: showBackButton && isDeclared
+                ? IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () => context.go('/teams-declaration-summary'),
+                  )
+                : null,
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            title: Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: Text(
+                toDayDate,
+                style: textStylePageDate(),
+              ),
+            ),
+            actions: actions,
+          );
+        }
+      },
     );
   }
 

--- a/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
+++ b/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
@@ -18,19 +18,6 @@ class AppBarWithDate extends ConsumerWidget implements PreferredSizeWidget {
 
     final isAlreadyDeclared = ref.watch(declarationProvider).isAlreadyDeclared;
 
-    // Future<bool> getIsDeclared() async {
-    //   return await ref
-    //       .read(declarationProvider.notifier)
-    //       .getLatestDeclaration();
-    // }
-
-    // return FutureBuilder<bool>(
-    //   future: getIsDeclared(),
-    //   builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
-    //     if (snapshot.connectionState == ConnectionState.waiting) {
-    //       return const CircularProgressIndicator(); // or some other widget while waiting for data
-    //     } else {
-    //       final isDeclared = snapshot.data ?? false;
     return AppBar(
       centerTitle: false,
       automaticallyImplyLeading: showBackButton && isAlreadyDeclared,

--- a/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
+++ b/yaki_mobile/lib/presentation/features/shared/app_bar_date.dart
@@ -17,7 +17,7 @@ class AppBarWithDate extends ConsumerWidget implements PreferredSizeWidget {
     final showBackButton = currentRoute == 'team-selection';
 
     final isAlreadyDeclared = ref.watch(declarationProvider).isAlreadyDeclared;
-    print(isAlreadyDeclared);
+
     // Future<bool> getIsDeclared() async {
     //   return await ref
     //       .read(declarationProvider.notifier)

--- a/yaki_mobile/lib/presentation/state/notifiers/declaration_notifier.dart
+++ b/yaki_mobile/lib/presentation/state/notifiers/declaration_notifier.dart
@@ -24,11 +24,15 @@ class DeclarationNotifier extends StateNotifier<DeclarationStatus> {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     final int? userId = prefs.getInt("userId");
 
-    if (userId == null) return false;
+    if (userId == null) {
+      state = state.copyWith(isAlreadyDeclared: false);
+      return false;
+    }
 
     final bool isAlreadyDeclared =
         await declarationRepository.getLatestDeclaration(userId);
 
+    state = state.copyWith(isAlreadyDeclared: isAlreadyDeclared);
     return isAlreadyDeclared;
   }
 
@@ -131,6 +135,7 @@ class DeclarationNotifier extends StateNotifier<DeclarationStatus> {
     );
     // SEND TO REPOSITORY
     await declarationRepository.createFullDay(newDeclaration);
+    state = state.copyWith(isAlreadyDeclared: true);
   }
 
   /// Create declaration for the morning by setting
@@ -177,6 +182,7 @@ class DeclarationNotifier extends StateNotifier<DeclarationStatus> {
       newDeclarationAfternoon,
     ];
     await declarationRepository.createHalfDay(declarations);
+    state = state.copyWith(isAlreadyDeclared: true);
   }
 
   // ABSENCE declaration creation.
@@ -211,6 +217,7 @@ class DeclarationNotifier extends StateNotifier<DeclarationStatus> {
     state = state.copyWith(
       dateAbsenceStart: dateStart,
       dateAbsenceEnd: dateEnd,
+      isAlreadyDeclared: true,
     );
   }
 


### PR DESCRIPTION
# Description
add a back button in team-selection 

# Linked Issues
#1024 

# Changes
this is a feat . Add an appBar on the team_selection with a back button who return on the previous page (conditionnal rendering depending of if the logged user has a declaration or not)
If the user is logged and have a declaration display the back button to return of team-declaration-summary screen, else don't show the button

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
