### PR TITLE
Fix/kisweb and password view

### DIFF
--- a/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
+++ b/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
@@ -135,11 +135,12 @@ class AvatarModalState extends ConsumerState<AvatarModal> {
                     onPressed: () => pickImage(ImageSource.camera),
                   ),
                   const SizedBox(height: 10),
-                  Button.secondary(
-                    text: tr('imgGallery'),
-                    onPressed:
-                        kIsWeb ? null : () => pickImage(ImageSource.gallery),
-                  ),
+                  kIsWeb
+                      ? const SizedBox.shrink()
+                      : Button.secondary(
+                          text: tr('imgGallery'),
+                          onPressed: () => pickImage(ImageSource.gallery),
+                        ),
                   const SizedBox(height: 10),
                   if (_imageFile != null)
                     ClipRRect(

--- a/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
+++ b/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
@@ -136,7 +137,8 @@ class AvatarModalState extends ConsumerState<AvatarModal> {
                   const SizedBox(height: 10),
                   Button.secondary(
                     text: tr('imgGallery'),
-                    onPressed: () => pickImage(ImageSource.gallery),
+                    onPressed:
+                        kIsWeb ? null : () => pickImage(ImageSource.gallery),
                   ),
                   const SizedBox(height: 10),
                   if (_imageFile != null)

--- a/yaki_mobile/lib/presentation/ui/password/change_password.dart
+++ b/yaki_mobile/lib/presentation/ui/password/change_password.dart
@@ -82,72 +82,74 @@ class _ChangePasswordState extends ConsumerState<ChangePassword> {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 30),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(bottom: 40),
-                child: Text(
-                  tr('changePasswordPageTitle'),
-                  style: registrationPageTitleTextStyle(),
-                ),
-              ),
-              Form(
-                key: _formKey,
-                child: Column(
-                  children: [
-                    InputRegistration(
-                      textInputAction: TextInputAction.next,
-                      controller: currentPassword,
-                      label: tr('changePasswordPageOldPW'),
-                      validatorFunction: passwordValidator,
-                      isShown: true,
-                    ),
-                    InputRegistration(
-                      textInputAction: TextInputAction.next,
-                      controller: newPassword,
-                      label: tr('changePasswordPageNewPW'),
-                      validatorFunction: passwordValidator,
-                      isShown: true,
-                    ),
-                    InputRegistration(
-                      textInputAction: TextInputAction.done,
-                      controller: newPasswordConfirmation,
-                      label: tr('changePasswordPageNewPWConfirm'),
-                      validatorFunction: (value) =>
-                          pwConfirmationValidator(value, newPassword.text),
-                      isShown: true,
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 40),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: ConfirmationElevatedButton(
-                    text: tr('changePasswordPageConfimButton'),
-                    onPressed: passwordChangeValidation,
-                    foregroundColor: const Color.fromARGB(212, 183, 146, 14),
-                    backgroundColor: const Color.fromARGB(255, 220, 219, 219),
-                    btnTextStyle: registrationBtnTextStyle(),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 40),
+                  child: Text(
+                    tr('changePasswordPageTitle'),
+                    style: registrationPageTitleTextStyle(),
                   ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 25),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: ConfirmationElevatedButton(
-                    text: tr('registrationCancelButton'),
-                    onPressed: () => context.go("/profile"),
-                    foregroundColor: const Color.fromARGB(212, 183, 146, 14),
-                    backgroundColor: const Color.fromARGB(255, 107, 97, 96),
-                    btnTextStyle: registrationCancelTextStyle(),
+                Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      InputRegistration(
+                        textInputAction: TextInputAction.next,
+                        controller: currentPassword,
+                        label: tr('changePasswordPageOldPW'),
+                        validatorFunction: passwordValidator,
+                        isShown: true,
+                      ),
+                      InputRegistration(
+                        textInputAction: TextInputAction.next,
+                        controller: newPassword,
+                        label: tr('changePasswordPageNewPW'),
+                        validatorFunction: passwordValidator,
+                        isShown: true,
+                      ),
+                      InputRegistration(
+                        textInputAction: TextInputAction.done,
+                        controller: newPasswordConfirmation,
+                        label: tr('changePasswordPageNewPWConfirm'),
+                        validatorFunction: (value) =>
+                            pwConfirmationValidator(value, newPassword.text),
+                        isShown: true,
+                      ),
+                    ],
                   ),
                 ),
-              ),
-            ],
+                Padding(
+                  padding: const EdgeInsets.only(top: 40),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ConfirmationElevatedButton(
+                      text: tr('changePasswordPageConfimButton'),
+                      onPressed: passwordChangeValidation,
+                      foregroundColor: const Color.fromARGB(212, 183, 146, 14),
+                      backgroundColor: const Color.fromARGB(255, 220, 219, 219),
+                      btnTextStyle: registrationBtnTextStyle(),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 25),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ConfirmationElevatedButton(
+                      text: tr('registrationCancelButton'),
+                      onPressed: () => context.go("/profile"),
+                      foregroundColor: const Color.fromARGB(212, 183, 146, 14),
+                      backgroundColor: const Color.fromARGB(255, 107, 97, 96),
+                      btnTextStyle: registrationCancelTextStyle(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
# Description

When a functionality is not allow on PWA, we must add a IsKWeb to disabled it and display a modal 'coming soon'
As user when i want to change my password in the profile screen, the keyboard as show in front of the input to i can't see my change,

# Linked Issues
#1031
#1028 

# Changes

Add a KisWeb on the import from gallery functionality to hide button, add a SingleChildScrollView on the change password screen to see the keyboard and the input

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
