### PR TITLE
feat(LockRotateScreen): Lock portaitMode

### DIFF
--- a/yaki_mobile/lib/main.dart
+++ b/yaki_mobile/lib/main.dart
@@ -10,6 +10,12 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await EasyLocalization.ensureInitialized();
 
+  // Lock device orientation
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
+
   runApp(
     EasyLocalization(
       supportedLocales: const [


### PR DESCRIPTION
# Description
We musn't be able to rotate the phone when we are on the app
so add line in main to lock in portrait mode 

# Linked Issues
#968 

# Changes
add code in main.dart setPreferredOrientations

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
