### PR TITLE
fix(teamName_change): set ability back to edit the team name

### DIFF
--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -51,11 +51,11 @@ const setTeamDescription = (value: any) => {};
         <div class="popup__input-container">
           <input-text
             label-text="Team name"
-            @inputValue.prevent="setTeamName" />
+            @inputValue="setTeamName" />
 
           <input-text-area
             label-text="'Team description'"
-            @inputValue.prevent="setTeamDescription" />
+            @inputValue="setTeamDescription" />
 
           <section class="container__buttons--popup">
             <button-text-sized

--- a/yaki_admin/src/components/SideBarMenuDropDown.vue
+++ b/yaki_admin/src/components/SideBarMenuDropDown.vue
@@ -11,6 +11,7 @@ import {selectTeamAndFetchTeammates} from "@/features/captain/services/teamList.
 import modalState from "@/features/modal/services/modalState";
 import {MODALMODE} from "@/constants/modalMode";
 import router from "@/router/router";
+import {TeamType} from "@/models/team.type";
 
 const teamStore = useTeamStore();
 const roleStore = useRoleStore();
@@ -30,8 +31,9 @@ const onClickAddTeam = () => {
   modalState.switchModalVisibility(true, MODALMODE.teamCreate);
 };
 
-const onClickSelectTeam = (id: number) => {
-  selectTeamAndFetchTeammates(id);
+const onClickSelectTeam = (team: TeamType) => {
+  selectTeamAndFetchTeammates(team.id);
+  teamStore.setCaptainsIdWithinTeam(team.captainsId);
   router.push({path: "/captain/manage-team"});
 };
 
@@ -90,7 +92,7 @@ const props = defineProps({
           :key="index"
           v-bind:id="team.id"
           v-bind:teamName="team.teamName"
-          @click.prevent="() => onClickSelectTeam(team.id)" />
+          @click.prevent="() => onClickSelectTeam(team)" />
       </div>
       <div v-else>
         <p class="no-teams">There is no team yet</p>

--- a/yaki_admin/src/features/modal/services/modalState.ts
+++ b/yaki_admin/src/features/modal/services/modalState.ts
@@ -145,7 +145,7 @@ const modalState = reactive({
     const teamStore = useTeamStore();
     await teamStore.updateTeam(
       teamStore.getSelectedTeamId,
-      teamStore.getCaptainIdToBeAssign,
+      teamStore.getCaptainsIdWithinTeam[0],
       this.teamInputValue,
       null
     );

--- a/yaki_admin/src/models/team.type.ts
+++ b/yaki_admin/src/models/team.type.ts
@@ -2,6 +2,7 @@ export type TeamType = {
   id: number;
   teamName: string;
   customerId: number;
+  captainsId: number[];
   captains: CaptainDetails[];
 };
 

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -57,7 +57,6 @@ export const useTeamStore = defineStore("teamStore", {
       return false;
     },
 
-    // NOT USED YET
     setCaptainsIdWithinTeam(captainsId: number[]) {
       this.captainsIdForTeamSelected = captainsId;
     },


### PR DESCRIPTION
# Description
What are changes related to ?
Fix the team name edition that wasnt properly getting the connected captainId.
Leading to a team that was "unassigned" from the captain

# Linked Issues
What are the issues fixed by this pull request ?
#1130

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
