### PR TITLE
fix(form_validation): using enter will validate login and create/edit modal

### DIFF
--- a/yaki_admin/src/components/InputPassword.vue
+++ b/yaki_admin/src/components/InputPassword.vue
@@ -38,7 +38,8 @@ const switchPasswordVisibility = () => {
     <label for="input-pw"> {{ labelText }}</label>
     <button
       @click.prevent="switchPasswordVisibility"
-      class="input__password-btn-switch">
+      class="input__password-btn-switch"
+      type="button">
       <figure>
         <img
           :src="isPasswordVisible ? eyesClosedIcon : eyesOpenedIcon"

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -50,7 +50,7 @@ const setTeamDescription = (value: any) => {};
       </section>
 
       <section class="popup__content">
-        <div class="popup__input-container">
+        <form class="popup__input-container">
           <input-text
             label-text="Team name"
             @inputValue="setTeamName" />
@@ -63,14 +63,15 @@ const setTeamDescription = (value: any) => {};
             <button-text-sized
               text="Cancel"
               :color="BUTTONCOLORS.secondary"
-              @click.prevent="cancelModalBtn" />
-
+              @click.prevent="cancelModalBtn"
+              type="button" />
             <button-text-sized
               text="Modify"
               :color="BUTTONCOLORS.primary"
-              @click.prevent="validationModalAccept" />
+              @click.prevent="validationModalAccept"
+              type="submit" />
           </section>
-        </div>
+        </form>
       </section>
     </section>
   </section>

--- a/yaki_admin/src/features/login/components/LoginForm.vue
+++ b/yaki_admin/src/features/login/components/LoginForm.vue
@@ -61,7 +61,8 @@ export default {
 
         <button-primary
           text="SIGN IN"
-          @click.prevent="login" />
+          @click.prevent="login"
+          type="submit" />
         <buttonSecondary
           text="FORGOTTEN PASSWORD?"
           @click.prevent="forgottenPassword" />


### PR DESCRIPTION
# Description
What are changes related to ?

Fix issue where password input buton to reveal the password was the button used by the form while pressing enter
Fixed the modal for create or edit team to also validated with enter press. It was previewsly set with a form

# Linked Issues
What are the issues fixed by this pull request ?
#1137 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
