### PR TITLE
fix(promises): use promise.all() to make sure to have all promises resolve at once

### DIFF
--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -58,10 +58,11 @@ export const useTeamStore = defineStore("teamStore", {
      */
     async setTeamListOfACaptain(captainsId: number[]) {
       this.teamList = [];
-      for (const captainId of captainsId) {
-        const a = await teamService.getAllTeamsWithinCaptain(captainId);
-        this.teamList = this.getTeamList.concat(a);
-      }
+      const promises: Promise<TeamType[]>[] = captainsId.map((captainId) =>
+        teamService.getAllTeamsWithinCaptain(captainId)
+      );
+      const teams = await Promise.all(promises);
+      this.teamList = [...teams.flat()];
     },
 
     // add a selected user to a team

--- a/yaki_admin/tsconfig.json
+++ b/yaki_admin/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "exclude": ["./build/**/*"],
   "compilerOptions": {
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "outDir": "./build",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
# Description
What are changes related to ?

previews teams fetch per captainsid was set in a for..of creating possible issues during teams manipulations (create / delete / updated) that was requering to update the current team list, as not all Promises was handled at the same time.

Using Promise.all() resolve this issue as the code excecution will continue once all request are completed .

# Linked Issues
What are the issues fixed by this pull request ?
#1135 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
