### PR TITLE
fix(select_team): focus on the newly created team

### DIFF
--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -72,7 +72,7 @@ export const useModalStore = defineStore("userModalStore", {
       switch (this.getMode) {
         case MODALMODE.teamCreate:
           await this.handleTeamCreate();
-          break;
+          return;
         case MODALMODE.teamEdit:
           await this.handleTeamEdit();
           break;
@@ -87,7 +87,11 @@ export const useModalStore = defineStore("userModalStore", {
     },
     async handleTeamCreate() {
       const teamStore = useTeamStore();
-      await teamStore.createTeam(this.getTeamNameInputValue);
+      const createdTeam = await teamStore.createTeam(this.getTeamNameInputValue);
+
+      teamStore.setTeamInfoAndFetchTeammates(createdTeam);
+
+      await this.refreshTeamList();
     },
     async handleTeamEdit() {
       const teamStore = useTeamStore();

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -75,13 +75,13 @@ export const useTeamStore = defineStore("teamStore", {
      * Create a team, assign to the connected captain and his customer
      * @param teamName name of the team
      */
-    async createTeam(teamName: string): Promise<void> {
+    async createTeam(teamName: string): Promise<TeamType> {
       const selectedRoleStore = useSelectedRoleStore();
       const customerId = selectedRoleStore.getCustomerIdSelected;
       const captainId = selectedRoleStore.getCaptainIdSelected;
 
       //the back handle if the captainId is null or not
-      await teamService.createTeam(captainId, teamName, customerId);
+      return await teamService.createTeam(captainId, teamName, customerId);
     },
 
     /**


### PR DESCRIPTION
# Description
What are changes related to ?

When team is created, directly select it in the sidebar teamlist, the functionality will be more userfriendly.
And prepare the delete team delete screen feat.

# Linked Issues
What are the issues fixed by this pull request ?
#1136 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
