### PR TITLE
fix(input_content): fix input field content for creation or edition

### DIFF
--- a/yaki_admin/src/components/InputText.vue
+++ b/yaki_admin/src/components/InputText.vue
@@ -4,6 +4,10 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  inputValue: {
+    type: String,
+    required: true,
+  },
 });
 
 const emit = defineEmits(["inputValue"]);
@@ -20,6 +24,7 @@ const onInputUse = (e: Event) => {
       class="input__text input__no-border-background"
       type="text"
       placeholder=""
+      :value="inputValue"
       id="input-text" />
     <label for="input-text">{{ props.labelText }}</label>
   </section>

--- a/yaki_admin/src/components/InputTextArea.vue
+++ b/yaki_admin/src/components/InputTextArea.vue
@@ -4,6 +4,10 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  inputValue: {
+    type: String,
+    required: true,
+  },
 });
 
 const emit = defineEmits(["inputValue"]);
@@ -17,6 +21,7 @@ const onInputUse = (e: Event) => {
   <section class="input__border-background input__container-flex textarea__container-height-pos input__label-style">
     <textarea
       @input="onInputUse"
+      :value="inputValue"
       class="input__text input__no-border-background"
       placeholder=""
       id="textarea"

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -64,12 +64,13 @@ const setTeamDescription = (value: any) => {};
         <form class="popup__input-container">
           <input-text
             label-text="Team name"
+            :inputValue="modalStore.getTeamNameInputValue"
             @inputValue="setTeamName" />
 
           <input-text-area
             label-text="'Team description'"
+            :inputValue="''"
             @inputValue="setTeamDescription" />
-
           <section class="container__buttons--popup">
             <button-text-sized
               text="Cancel"

--- a/yaki_admin/src/router/router.ts
+++ b/yaki_admin/src/router/router.ts
@@ -17,7 +17,6 @@ import {TEAMPARAMS} from "@/constants/pathParam";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  // temporaty routing
   routes: [
     {
       path: "/",

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -48,12 +48,13 @@ export const useModalStore = defineStore("userModalStore", {
      * @param mode : MODALMODE to change modal content | null if modal is going to be hidden, this is not changing the previewsly set mode
      * @param teamName : Optionnal parameter, set teamName for edit name purpose, else ignore.
      */
-    switchModalVisibility(setVisible: boolean, mode: MODALMODE | null, teamName?: string) {
+    switchModalVisibility(setVisible: boolean, mode: MODALMODE | null) {
+      const teamStore = useTeamStore();
       // get current teamName and set it as input value for edition
-      if (teamName && mode === MODALMODE.teamEdit) {
-        this.setTeamNameInputValue(teamName);
+      if (teamStore.getTeamSelected.teamName && mode === MODALMODE.teamEdit) {
+        this.setTeamNameInputValue(teamStore.getTeamSelected.teamName);
       }
-      if (mode === MODALMODE.teamCreate) {
+      if (mode === MODALMODE.teamCreate || mode === MODALMODE.teamDelete) {
         this.setTeamNameInputValue("");
       }
 
@@ -61,6 +62,8 @@ export const useModalStore = defineStore("userModalStore", {
         this.setMode(mode!);
       }
       this.setIsShow(setVisible);
+
+      console.log(this.getTeamNameInputValue);
     },
 
     /**
@@ -94,6 +97,7 @@ export const useModalStore = defineStore("userModalStore", {
       teamStore.setTeamInfoAndFetchTeammates(createdTeam);
       await this.refreshTeamList();
 
+      this.setTeamNameInputValue("");
       return createdTeam;
     },
     /**
@@ -107,8 +111,8 @@ export const useModalStore = defineStore("userModalStore", {
         this.getTeamNameInputValue,
         null
       );
-      this.setTeamNameInputValue("");
       await this.refreshTeamList();
+      this.setTeamNameInputValue("");
     },
     /**
      * Delete the team.


### PR DESCRIPTION
# Description
What are changes related to ?

When creating a team the input field should be empty and reset after the team creation.
When editing the team, the input field should retrive the teamName for edit purpose, and reset afterward.

# Linked Issues
What are the issues fixed by this pull request ?
#1101 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
