### PR TITLE
fix(team_name): error message if user try to create a team without name

### DIFF
--- a/yaki_admin/src/components/InputText.vue
+++ b/yaki_admin/src/components/InputText.vue
@@ -8,6 +8,11 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  isError: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 });
 
 const emit = defineEmits(["inputValue"]);
@@ -15,10 +20,18 @@ const emit = defineEmits(["inputValue"]);
 const onInputUse = (e: Event) => {
   emit("inputValue", (e.target as HTMLInputElement).value);
 };
+
+const classList = [
+  "input__border-background",
+  "input__container-flex",
+  "input__container-height",
+  "input__label-style",
+];
 </script>
 
 <template>
-  <section class="input__border-background input__container-flex input__container-height input__label-style">
+  <section :class="[classList, props.isError ? 'input__error' : '']">
+    <div class="input-warning"></div>
     <input
       @input="onInputUse"
       class="input__text input__no-border-background"
@@ -29,3 +42,15 @@ const onInputUse = (e: Event) => {
     <label for="input-text">{{ props.labelText }}</label>
   </section>
 </template>
+
+<style scoped lang="scss">
+.input__error:after {
+  content: "You must provide a team name !";
+  position: absolute;
+  bottom: 6%;
+  left: 25px;
+  font-size: 0.8rem;
+  font-weight: 900;
+  color: red;
+}
+</style>

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -13,14 +13,22 @@ import {isATeamType} from "@/models/team.type";
 import {MODALMODE} from "@/constants/modalMode";
 import router from "@/router/router";
 import {TEAMPARAMS} from "@/constants/pathParam";
+import {ref} from "vue";
 
 const modalStore = useModalStore();
+const isMissingTeamNameError = ref(false);
 
 const onCancelPress = () => {
   modalStore.switchModalVisibility(false, null);
+  isMissingTeamNameError.value = false;
 };
 
 const onAcceptPress = async () => {
+  if (modalStore.getTeamNameInputValue === "") {
+    isMissingTeamNameError.value = true;
+    return;
+  }
+
   const result = await modalStore.validationActions();
   modalStore.switchModalVisibility(false, null);
 
@@ -35,6 +43,9 @@ const onAcceptPress = async () => {
 };
 
 const setTeamName = (value: any) => {
+  if (value !== "") {
+    isMissingTeamNameError.value = false;
+  }
   modalStore.setTeamNameInputValue(value);
 };
 
@@ -65,6 +76,7 @@ const setTeamDescription = (value: any) => {};
           <input-text
             label-text="Team name"
             :inputValue="modalStore.getTeamNameInputValue"
+            :isError="isMissingTeamNameError"
             @inputValue="setTeamName" />
 
           <input-text-area


### PR DESCRIPTION
# Description
What are changes related to ?

If a user try to create a team without a name, the create team will be blocked an a warning message will be displayed

# Linked Issues
What are the issues fixed by this pull request ?
#865 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="653" alt="Capture d’écran 2023-11-30 à 14 04 49" src="https://github.com/XPEHO/YAKI/assets/95299697/bff5dc18-da84-40e2-bca3-65d10972e5d0">

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
