### PR TITLE
feat(description_team_front): fetch description

### DIFF
--- a/yaki_admin/README.md
+++ b/yaki_admin/README.md
@@ -4,9 +4,9 @@ Yaki is Working localization declaration app.
 
 Yaki admin frontend is the desktop front-end of the Admin Yaki application, so that :
 
-- the owner can manage his customer
-- the customer can manage his captain
-- the captain can manage their teams and teamMates
+- the owner can manage his customer,
+- the customer can manage his captain,
+- the captain can manage their teams and teamMates.
 
 ## Recommended IDE Setup
 

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -84,12 +84,8 @@ const setTeamDescription = (value: any) => {
 
           <input-text-area
             label-text="'Team description'"
-            :inputValue="''"
-            @emittedInput="setTeamDescription" />
-
             :inputValue="modalStore.getTeamDescriptionInputValue"
-            :isError="isMissingTeamDescriptionError"
-            @inputValue="setTeamDescription" />
+            @emittedInput="setTeamDescription" />
 
           <section class="container__buttons--popup">
             <button-text-sized

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -13,12 +13,14 @@ import { ref } from "vue";
 
 const modalStore = useModalStore();
 const isMissingTeamNameError = ref(false);
+const isMissingTeamDescriptionError = ref(false);
 
 const emit = defineEmits(["onAccept", "onCancel"]);
 
 const onCancelPress = () => {
   emit("onCancel");
   isMissingTeamNameError.value = false;
+  isMissingTeamDescriptionError.value = false;
 };
 
 /**
@@ -29,6 +31,7 @@ const onCancelPress = () => {
 const onAcceptPress = async () => {
   if (modalStore.getTeamNameInputValue === "") {
     isMissingTeamNameError.value = true;
+    isMissingTeamDescriptionError.value = true;
     return;
   }
   emit("onAccept");
@@ -45,12 +48,13 @@ const setTeamName = (value: any) => {
   }
   modalStore.setTeamNameInputValue(value);
 };
-console.log("modalCreateEditTeam", setTeamName);
 
 const setTeamDescription = (value: any) => {
+  if (value !== "") {
+    isMissingTeamDescriptionError.value = false;
+  }
   modalStore.setTeamDescriptionInputValue(value);
 };
-console.log("modalCreateEditTeam", setTeamDescription);
 </script>
 
 <template>
@@ -80,13 +84,13 @@ console.log("modalCreateEditTeam", setTeamDescription);
 
           <input-text-area
             label-text="'Team description'"
-<<<<<<< HEAD
             :inputValue="''"
             @emittedInput="setTeamDescription" />
-=======
+
             :inputValue="modalStore.getTeamDescriptionInputValue"
+            :isError="isMissingTeamDescriptionError"
             @inputValue="setTeamDescription" />
->>>>>>> 7bb7023f (feat(description_team_front): fetch description)
+
           <section class="container__buttons--popup">
             <button-text-sized
               text="Cancel"

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -7,9 +7,9 @@ import ButtonTextSized from "./ButtonTextSized.vue";
 import pencilIcon from "@/assets/images/pencil-regular-24.png";
 import deleteIcon from "@/assets/images/x_close.png";
 
-import {BUTTONCOLORS} from "@/constants/componentsSettings";
-import {useModalStore} from "@/stores/modalStore";
-import {ref} from "vue";
+import { BUTTONCOLORS } from "@/constants/componentsSettings";
+import { useModalStore } from "@/stores/modalStore";
+import { ref } from "vue";
 
 const modalStore = useModalStore();
 const isMissingTeamNameError = ref(false);
@@ -46,7 +46,9 @@ const setTeamName = (value: any) => {
   modalStore.setTeamNameInputValue(value);
 };
 
-const setTeamDescription = (value: any) => {};
+const setTeamDescription = (value: any) => {
+  modalStore.setTeamDescriptionInputValue(value);
+};
 </script>
 
 <template>
@@ -57,9 +59,7 @@ const setTeamDescription = (value: any) => {};
     <section class="popup__content">
       <section class="popup__avatar-section">
         <figure>
-          <img
-            src="../assets/images/avatar_2.png"
-            alt="avatar" />
+          <img src="../assets/images/avatar_2.png" alt="avatar" />
         </figure>
 
         <aside class="container__buttons">
@@ -78,8 +78,13 @@ const setTeamDescription = (value: any) => {};
 
           <input-text-area
             label-text="'Team description'"
+<<<<<<< HEAD
             :inputValue="''"
             @emittedInput="setTeamDescription" />
+=======
+            :inputValue="modalStore.getTeamDescriptionInputValue"
+            @inputValue="setTeamDescription" />
+>>>>>>> 7bb7023f (feat(description_team_front): fetch description)
           <section class="container__buttons--popup">
             <button-text-sized
               text="Cancel"

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -50,9 +50,6 @@ const setTeamName = (value: any) => {
 };
 
 const setTeamDescription = (value: any) => {
-  if (value !== "") {
-    isMissingTeamDescriptionError.value = false;
-  }
   modalStore.setTeamDescriptionInputValue(value);
 };
 </script>

--- a/yaki_admin/src/components/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/components/ModalCreateEditTeam.vue
@@ -45,10 +45,12 @@ const setTeamName = (value: any) => {
   }
   modalStore.setTeamNameInputValue(value);
 };
+console.log("modalCreateEditTeam", setTeamName);
 
 const setTeamDescription = (value: any) => {
   modalStore.setTeamDescriptionInputValue(value);
 };
+console.log("modalCreateEditTeam", setTeamDescription);
 </script>
 
 <template>

--- a/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
+++ b/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
@@ -8,6 +8,7 @@ import { useModalStore } from "@/stores/modalStore";
 const teammateStore = useTeammateStore();
 const modalStore = useModalStore();
 
+console.log("captainPageContent", modalStore.getTeamDescriptionInputValue);
 </script>
 
 <template>

--- a/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
+++ b/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
@@ -3,12 +3,10 @@ import PageContentHeader from "@/features/captain/layouts/PageContentHeader.vue"
 import PageContentLayout from "@/layouts/PageContentLayout.vue";
 import UserInfoCard from "@/components/UserInfoCard.vue";
 import { useTeammateStore } from "@/stores/teammateStore";
-import { useModalStore } from "@/stores/modalStore";
+import { useTeamStore } from "@/stores/teamStore";
 
 const teammateStore = useTeammateStore();
-const modalStore = useModalStore();
-
-console.log("captainPageContent", modalStore.getTeamDescriptionInputValue);
+const teamStore = useTeamStore();
 </script>
 
 <template>
@@ -18,7 +16,9 @@ console.log("captainPageContent", modalStore.getTeamDescriptionInputValue);
     </template>
     <template #content>
       <section class="user-list__container">
-        <p>Team description : {{ modalStore.getTeamDescriptionInputValue }}</p>
+        <p>
+          Team description : {{ teamStore.getTeamSelected.teamDescription }}
+        </p>
         <p
           v-if="
             teammateStore.getTeammateList &&

--- a/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
+++ b/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
@@ -2,9 +2,11 @@
 import PageContentHeader from "@/features/captain/layouts/PageContentHeader.vue";
 import PageContentLayout from "@/layouts/PageContentLayout.vue";
 import UserInfoCard from "@/components/UserInfoCard.vue";
-import {useTeammateStore} from "@/stores/teammateStore";
+import { useTeammateStore } from "@/stores/teammateStore";
+import { useModalStore } from "@/stores/modalStore";
 
 const teammateStore = useTeammateStore();
+const modalStore = useModalStore();
 </script>
 
 <template>
@@ -14,8 +16,14 @@ const teammateStore = useTeammateStore();
     </template>
     <template #content>
       <section class="user-list__container">
-        <p>Team description : Coming soon.</p>
-        <p v-if="teammateStore.getTeammateList && teammateStore.getTeammateList.length > 0">Teammates :</p>
+        <p>Team description : {{ modalStore.getTeamDescriptionInputValue }}</p>
+        <p
+          v-if="
+            teammateStore.getTeammateList &&
+            teammateStore.getTeammateList.length > 0
+          ">
+          Teammates :
+        </p>
         <section class="user-list__in-team-container">
           <user-info-card
             v-for="teammate in teammateStore.getTeammateList"

--- a/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
+++ b/yaki_admin/src/features/captain/layouts/CaptainPageContent.vue
@@ -7,6 +7,7 @@ import { useModalStore } from "@/stores/modalStore";
 
 const teammateStore = useTeammateStore();
 const modalStore = useModalStore();
+
 </script>
 
 <template>

--- a/yaki_admin/src/features/customer/components/TeamWithCaptainCard.vue
+++ b/yaki_admin/src/features/customer/components/TeamWithCaptainCard.vue
@@ -22,7 +22,7 @@ const props = defineProps({
 });
 
 const acceptFunc = async () => {
-  await teamStore.updateTeam(props.teamContent.id, teamStore.getCaptainIdToBeAssign, modalState.teamInputValue, null);
+  await teamStore.updateTeam(props.teamContent.id, teamStore.getCaptainIdToBeAssign, modalState.teamInputValue, null, null);
   isEdit.value = !isEdit.value;
   await teamStore.setTeamsFromCustomer();
 };

--- a/yaki_admin/src/features/customer/layouts/CustomerPageContentTeamList.vue
+++ b/yaki_admin/src/features/customer/layouts/CustomerPageContentTeamList.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-import {onBeforeMount} from "vue";
+import { onBeforeMount } from "vue";
 
 import HeaderContentPage from "@/features/shared/components/HeaderContentPage.vue";
-import {useTeamStore} from "@/stores/teamStore";
+import { useTeamStore } from "@/stores/teamStore";
 import modalState from "@/features/modal/services/modalState";
-import {MODALMODE} from "@/constants/modalMode";
+import { MODALMODE } from "@/constants/modalMode";
 
 import PageContentLayout from "@/layouts/PageContentLayout.vue";
 import SideBarButton from "@/features/shared/components/SideBarButton.vue";
 import TeamWithCaptainCard from "@/features/customer/components/TeamWithCaptainCard.vue";
 import plusIcon from "@/assets/images/plus.png";
-import {useCaptainStore} from "@/stores/captainStore";
-import {useSelectedRoleStore} from "@/stores/selectedRole";
+import { useCaptainStore } from "@/stores/captainStore";
+import { useSelectedRoleStore } from "@/stores/selectedRole";
 
 const teamStore = useTeamStore();
 const captainStore = useCaptainStore();
@@ -19,7 +19,9 @@ const selectedRoleStore = useSelectedRoleStore();
 
 onBeforeMount(async () => {
   await teamStore.setTeamsFromCustomer();
-  await captainStore.setAllCaptainsByCustomerId(selectedRoleStore.getCustomerIdSelected);
+  await captainStore.setAllCaptainsByCustomerId(
+    selectedRoleStore.getCustomerIdSelected
+  );
 });
 
 const customerTeamCreation = () => {
@@ -47,4 +49,3 @@ const customerTeamCreation = () => {
     </template>
   </page-content-layout>
 </template>
-@/constants/modalMode @/constants/modalMode @/features/modal/services/modalState

--- a/yaki_admin/src/features/modal/services/modalState.ts
+++ b/yaki_admin/src/features/modal/services/modalState.ts
@@ -1,8 +1,8 @@
-import {reactive} from "vue";
-import {useTeamStore} from "@/stores/teamStore.js";
-import {MODALMODE} from "@/constants/modalMode";
-import {useTeammateStore} from "@/stores/teammateStore";
-import {useRoleStore} from "@/stores/roleStore";
+import { reactive } from "vue";
+import { useTeamStore } from "@/stores/teamStore.js";
+import { MODALMODE } from "@/constants/modalMode";
+import { useTeammateStore } from "@/stores/teammateStore";
+import { useRoleStore } from "@/stores/roleStore";
 
 // DEPRECIATED REMOVE WHEN CUSTOMER IS MADE
 //==================================================================================================
@@ -12,16 +12,24 @@ const modalState = reactive({
   mode: "" as MODALMODE,
   teamInputValue: "" as string,
   teamName: "" as string,
+  teamDescription: "" as string,
 
   defaultButtonValue: "Select a captain" as string,
   dropDownButtonText: "Select a captain" as string,
   dropDownSelectedCaptainId: null as number | null,
 
-  switchModalVisibility(setVisible: boolean, mode: MODALMODE | null, teamName?: string) {
+  switchModalVisibility(
+    setVisible: boolean,
+    mode: MODALMODE | null,
+    teamName?: string
+  ) {
     if (teamName && mode === MODALMODE.teamEdit) {
       this.setTeamInputValue(teamName);
     }
-    if (mode === MODALMODE.teamCreate || mode === MODALMODE.teamCreateCustomer) {
+    if (
+      mode === MODALMODE.teamCreate ||
+      mode === MODALMODE.teamCreateCustomer
+    ) {
       this.setTeamInputValue("");
     }
 
@@ -84,7 +92,7 @@ const modalState = reactive({
 
   async createNewteam() {
     const teamStore = useTeamStore();
-    await teamStore.createTeam(this.teamInputValue);
+    await teamStore.createTeam(this.teamName, this.teamDescription);
     this.refreshTeamList();
   },
 
@@ -94,7 +102,8 @@ const modalState = reactive({
       teamStore.getTeamSelected.id,
       teamStore.getTeamSelected.captainsId[0],
       this.teamInputValue,
-      null
+      null,
+      this.teamInputValue
     );
     this.refreshTeamList();
     //reset value
@@ -114,7 +123,9 @@ const modalState = reactive({
 
   async deleteUserFromTeam() {
     const teammateStore = useTeammateStore();
-    await teammateStore.deleteTeammateFromTeam(teammateStore.getIdOfTeammateToDelete);
+    await teammateStore.deleteTeammateFromTeam(
+      teammateStore.getIdOfTeammateToDelete
+    );
     this.refreshTeammatesList();
   },
 
@@ -143,7 +154,11 @@ const modalState = reactive({
 
   async createNewTeamWithOptionalCaptain() {
     const teamStore = useTeamStore();
-    teamStore.createTeamOptionalAssignCaptain(this.teamInputValue, teamStore.getCaptainIdToBeAssign);
+    teamStore.createTeamOptionalAssignCaptain(
+      this.teamName,
+      teamStore.getCaptainIdToBeAssign,
+      this.teamDescription
+    );
     this.refreshTeamListForCustomer();
     //reset values
     teamStore.setCaptainIdToBeAssign(null);

--- a/yaki_admin/src/models/team.type.ts
+++ b/yaki_admin/src/models/team.type.ts
@@ -4,6 +4,7 @@ export type TeamType = {
   customerId: number;
   captainsId: number[];
   captains: CaptainDetails[];
+  description: string;
 };
 
 export function isATeamType(obj: any): obj is TeamType {
@@ -13,7 +14,8 @@ export function isATeamType(obj: any): obj is TeamType {
     typeof obj.teamName === "string" &&
     typeof obj.customerId === "number" &&
     Array.isArray(obj.captainsId) &&
-    obj.captainsId.every((id: number) => typeof id === "number")
+    obj.captainsId.every((id: number) => typeof id === "number") &&
+    typeof obj.description === "string"
   );
 }
 
@@ -27,4 +29,5 @@ export type TeamTypeOut = {
   captainsId: (number | null)[];
   teamName: string | null;
   customerId: number | null;
+  description: string | null;
 };

--- a/yaki_admin/src/models/team.type.ts
+++ b/yaki_admin/src/models/team.type.ts
@@ -4,7 +4,7 @@ export type TeamType = {
   customerId: number;
   captainsId: number[];
   captains: CaptainDetails[];
-  description: string;
+  teamDescription: string | null;
 };
 
 export function isATeamType(obj: any): obj is TeamType {
@@ -15,7 +15,7 @@ export function isATeamType(obj: any): obj is TeamType {
     typeof obj.customerId === "number" &&
     Array.isArray(obj.captainsId) &&
     obj.captainsId.every((id: number) => typeof id === "number") &&
-    typeof obj.description === "string"
+    typeof obj.teamDescription === "string"
   );
 }
 
@@ -29,5 +29,5 @@ export type TeamTypeOut = {
   captainsId: (number | null)[];
   teamName: string | null;
   customerId: number | null;
-  description: string | null;
+  teamDescription: string | null;
 };

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -1,7 +1,7 @@
-import type {TeamType, TeamTypeOut} from "../models/team.type";
-import {environmentVar} from "@/envPlaceholder";
-import {authHeader} from "@/utils/authUtils";
-import {handleResponse} from "@/utils/responseUtils";
+import type { TeamType, TeamTypeOut } from "../models/team.type";
+import { environmentVar } from "@/envPlaceholder";
+import { authHeader } from "@/utils/authUtils";
+import { handleResponse } from "@/utils/responseUtils";
 
 const URL: string = environmentVar.baseURL;
 
@@ -34,8 +34,18 @@ export class TeamService {
     return response;
   };
 
-  createTeam = async (cptId: number | null, teamName: string, customerId: number): Promise<TeamType> => {
-    const newTeam: TeamTypeOut = {captainsId: [cptId], teamName: teamName, customerId: customerId};
+  createTeam = async (
+    cptId: number | null,
+    teamName: string,
+    customerId: number,
+    description: string | null
+  ): Promise<TeamType> => {
+    const newTeam: TeamTypeOut = {
+      captainsId: [cptId],
+      teamName: teamName,
+      customerId: customerId,
+      description: description,
+    };
     const requestOptions = {
       method: "POST",
       body: JSON.stringify(newTeam),
@@ -53,9 +63,15 @@ export class TeamService {
     teamId: number,
     cptId: number | null,
     teamName: string | null,
-    customerId: number | null
+    customerId: number | null,
+    description: string | null
   ): Promise<TeamType> => {
-    const updatedTeam: TeamTypeOut = {captainsId: [cptId], teamName: teamName, customerId: customerId};
+    const updatedTeam: TeamTypeOut = {
+      captainsId: [cptId],
+      teamName: teamName,
+      customerId: customerId,
+      description: description,
+    };
     const requestOptions = {
       method: "PUT",
       body: JSON.stringify(updatedTeam),

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -38,13 +38,13 @@ export class TeamService {
     cptId: number | null,
     teamName: string,
     customerId: number,
-    description: string | null
+    teamDescription: string | null
   ): Promise<TeamType> => {
     const newTeam: TeamTypeOut = {
       captainsId: [cptId],
       teamName: teamName,
       customerId: customerId,
-      description: description,
+      teamDescription: teamDescription,
     };
     const requestOptions = {
       method: "POST",
@@ -64,13 +64,13 @@ export class TeamService {
     cptId: number | null,
     teamName: string | null,
     customerId: number | null,
-    description: string | null
+    teamDescription: string | null
   ): Promise<TeamType> => {
     const updatedTeam: TeamTypeOut = {
       captainsId: [cptId],
       teamName: teamName,
       customerId: customerId,
-      description: description,
+      teamDescription: teamDescription,
     };
     const requestOptions = {
       method: "PUT",

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -54,7 +54,6 @@ export class TeamService {
     const res = await fetch(`${URL}/teams`, requestOptions)
       .then(handleResponse)
       .catch((err) => console.warn(err));
-    console.log("service: createTeam", res);
 
     return res;
   };
@@ -78,14 +77,10 @@ export class TeamService {
       body: JSON.stringify(updatedTeam),
       headers: authHeader(`${URL}/teams/${teamId}`),
     };
-    
-    console.log("service: updateTeam", requestOptions.body);
 
     const res = await fetch(`${URL}/teams/${teamId}`, requestOptions)
       .then(handleResponse)
       .catch((err) => console.warn(err));
-
-    console.log("service: updateTeam", res);
 
     return res;
   };

--- a/yaki_admin/src/services/team.service.ts
+++ b/yaki_admin/src/services/team.service.ts
@@ -38,7 +38,7 @@ export class TeamService {
     cptId: number | null,
     teamName: string,
     customerId: number,
-    teamDescription: string | null
+    teamDescription: string
   ): Promise<TeamType> => {
     const newTeam: TeamTypeOut = {
       captainsId: [cptId],
@@ -54,6 +54,7 @@ export class TeamService {
     const res = await fetch(`${URL}/teams`, requestOptions)
       .then(handleResponse)
       .catch((err) => console.warn(err));
+    console.log("service: createTeam", res);
 
     return res;
   };
@@ -77,9 +78,14 @@ export class TeamService {
       body: JSON.stringify(updatedTeam),
       headers: authHeader(`${URL}/teams/${teamId}`),
     };
+    
+    console.log("service: updateTeam", requestOptions.body);
+
     const res = await fetch(`${URL}/teams/${teamId}`, requestOptions)
       .then(handleResponse)
       .catch((err) => console.warn(err));
+
+    console.log("service: updateTeam", res);
 
     return res;
   };

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -1,15 +1,16 @@
-import {MODALMODE} from "@/constants/modalMode";
-import {defineStore} from "pinia";
-import {useTeamStore} from "@/stores/teamStore";
-import {useTeammateStore} from "@/stores/teammateStore";
-import {useRoleStore} from "@/stores/roleStore";
-import {TeamType} from "@/models/team.type";
+import { MODALMODE } from "@/constants/modalMode";
+import { defineStore } from "pinia";
+import { useTeamStore } from "@/stores/teamStore";
+import { useTeammateStore } from "@/stores/teammateStore";
+import { useRoleStore } from "@/stores/roleStore";
+import { TeamType } from "@/models/team.type";
 
 interface State {
   isShow: boolean;
   mode: MODALMODE;
   teamNameInputValue: string;
   teammateNameToDelete: string;
+  teamDescriptionInputValue: string;
 }
 
 export const useModalStore = defineStore("userModalStore", {
@@ -18,12 +19,15 @@ export const useModalStore = defineStore("userModalStore", {
     mode: "" as MODALMODE,
     teamNameInputValue: "" as string,
     teammateNameToDelete: "" as string,
+    teamDescriptionInputValue: "" as string,
   }),
   getters: {
     getIsShow: (state: State) => state.isShow,
     getMode: (state: State) => state.mode,
     getTeamNameInputValue: (state: State) => state.teamNameInputValue,
     getTeammateNameToDelete: (state: State) => state.teammateNameToDelete,
+    getTeamDescriptionInputValue: (state: State) =>
+      state.teamDescriptionInputValue,
   },
   actions: {
     setIsShow(isShow: boolean) {
@@ -37,6 +41,9 @@ export const useModalStore = defineStore("userModalStore", {
     },
     setTeammateNameToDelete(teammateName: string) {
       this.teammateNameToDelete = teammateName;
+    },
+    setTeamDescriptionInputValue(teamDescriptionInputValue: string) {
+      this.teamDescriptionInputValue = teamDescriptionInputValue;
     },
 
     /**
@@ -115,7 +122,8 @@ export const useModalStore = defineStore("userModalStore", {
         teamStore.getTeamSelected.id,
         teamStore.getTeamSelected.captainsId[0],
         this.getTeamNameInputValue,
-        null
+        null,
+        teamStore.getTeamSelected.description
       );
 
       teamStore.setTeamSelected(editedTeam);
@@ -141,7 +149,9 @@ export const useModalStore = defineStore("userModalStore", {
      */
     async handleUserDelete() {
       const teammateStore = useTeammateStore();
-      await teammateStore.deleteTeammateFromTeam(teammateStore.getIdOfTeammateToDelete);
+      await teammateStore.deleteTeammateFromTeam(
+        teammateStore.getIdOfTeammateToDelete
+      );
     },
 
     /**

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -114,7 +114,7 @@ export const useModalStore = defineStore("userModalStore", {
         this.getTeamNameInputValue,
         this.getTeamDescriptionInputValue
       );
-      console.log(createdTeam);
+  
       teamStore.setTeamInfoAndFetchTeammates(createdTeam);
       await this.refreshTeamList();
 

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -114,6 +114,7 @@ export const useModalStore = defineStore("userModalStore", {
         this.getTeamNameInputValue,
         this.getTeamDescriptionInputValue
       );
+      console.log(createdTeam);
       teamStore.setTeamInfoAndFetchTeammates(createdTeam);
       await this.refreshTeamList();
 
@@ -122,7 +123,7 @@ export const useModalStore = defineStore("userModalStore", {
       return createdTeam;
     },
     /**
-     * Edit the team name. Reset the input value afterwards.
+     * Edit the team name and the team description. Reset the input value afterwards.
      */
     async handleTeamEdit() {
       const teamStore = useTeamStore();
@@ -134,7 +135,7 @@ export const useModalStore = defineStore("userModalStore", {
         null,
         this.getTeamDescriptionInputValue
       );
-
+     
       teamStore.setTeamSelected(editedTeam);
       await this.refreshTeamList();
       this.setTeamNameInputValue("");

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -57,12 +57,18 @@ export const useModalStore = defineStore("userModalStore", {
      */
     switchModalVisibility(setVisible: boolean, mode: MODALMODE | null) {
       const teamStore = useTeamStore();
-      // get current teamName and set it as input value for edition
-      if (teamStore.getTeamSelected.teamName && mode === MODALMODE.teamEdit) {
-        this.setTeamNameInputValue(teamStore.getTeamSelected.teamName);
+      const { teamName, teamDescription } = teamStore.getTeamSelected;
+
+      // get current teamName and teamDescription and set it as input value for edition
+      if (mode === MODALMODE.teamEdit && teamName) {
+        this.setTeamNameInputValue(teamName);
+        if (teamDescription) {
+          this.setTeamDescriptionInputValue(teamDescription);
+        }
       }
       if (mode === MODALMODE.teamCreate || mode === MODALMODE.teamDelete) {
         this.setTeamNameInputValue("");
+        this.setTeamDescriptionInputValue("");
       }
 
       if (setVisible === true && mode !== null) {
@@ -104,12 +110,15 @@ export const useModalStore = defineStore("userModalStore", {
      */
     async handleTeamCreate(): Promise<TeamType> {
       const teamStore = useTeamStore();
-
-      const createdTeam = await teamStore.createTeam(this.getTeamNameInputValue);
+      const createdTeam = await teamStore.createTeam(
+        this.getTeamNameInputValue,
+        this.getTeamDescriptionInputValue
+      );
       teamStore.setTeamInfoAndFetchTeammates(createdTeam);
       await this.refreshTeamList();
 
       this.setTeamNameInputValue("");
+      this.setTeamDescriptionInputValue("");
       return createdTeam;
     },
     /**
@@ -123,12 +132,13 @@ export const useModalStore = defineStore("userModalStore", {
         teamStore.getTeamSelected.captainsId[0],
         this.getTeamNameInputValue,
         null,
-        teamStore.getTeamSelected.description
+        this.getTeamDescriptionInputValue
       );
 
       teamStore.setTeamSelected(editedTeam);
       await this.refreshTeamList();
       this.setTeamNameInputValue("");
+      this.setTeamDescriptionInputValue("");
     },
     /**
      * Delete the team.

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -105,6 +105,13 @@ export const useTeamStore = defineStore("teamStore", {
       const customerId = selectedRoleStore.getCustomerIdSelected;
       const captainId = selectedRoleStore.getCaptainIdSelected;
 
+      console.log(
+        "teamStore: createTeam",
+        teamName,
+        teamDescription,
+        customerId,
+        captainId
+      );
       //the back handle if the captainId is null or not
       return await teamService.createTeam(
         captainId,
@@ -131,6 +138,15 @@ export const useTeamStore = defineStore("teamStore", {
       customerId: number | null,
       teamDescription: string | null
     ): Promise<TeamType> {
+      console.log(
+        "teamStore: updateTeam",
+        teamID,
+        cptId,
+        teamName,
+        customerId,
+        teamDescription
+      );
+
       return await teamService.updateTeam(
         teamID,
         cptId,

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -94,20 +94,23 @@ export const useTeamStore = defineStore("teamStore", {
     /**
      * Create a team, assign to the connected captain and his customer
      * @param teamName name of the team
+     * @param teamDescription description of the team
      * @returns created team: TeamType
      */
-    async createTeam(teamName: string): Promise<TeamType> {
+    async createTeam(
+      teamName: string,
+      teamDescription: string
+    ): Promise<TeamType> {
       const selectedRoleStore = useSelectedRoleStore();
       const customerId = selectedRoleStore.getCustomerIdSelected;
       const captainId = selectedRoleStore.getCaptainIdSelected;
-      const description = null;
 
       //the back handle if the captainId is null or not
       return await teamService.createTeam(
         captainId,
         teamName,
         customerId,
-        description
+        teamDescription
       );
     },
 
@@ -118,7 +121,7 @@ export const useTeamStore = defineStore("teamStore", {
      * @param cptId captain of the team. This can be null if no captain is assigned.
      * @param teamName New team name. null if the team name is not being updated.
      * @param customerId id of the customer that the team belongs to.
-     *
+     * @param teamDescription New team description. null if the team description is not being updated.
      * @returns updated team: TeamType.
      */
     async updateTeam(
@@ -126,14 +129,14 @@ export const useTeamStore = defineStore("teamStore", {
       cptId: number | null,
       teamName: string | null,
       customerId: number | null,
-      description: string | null
+      teamDescription: string | null
     ): Promise<TeamType> {
       return await teamService.updateTeam(
         teamID,
         cptId,
         teamName,
         customerId,
-        description
+        teamDescription
       );
     },
 
@@ -155,13 +158,18 @@ export const useTeamStore = defineStore("teamStore", {
 
     async createTeamOptionalAssignCaptain(
       teamName: string,
-      captainId: number | null
+      captainId: number | null,
+      teamDescription: string
     ): Promise<void> {
       const selectedRoleStore = useSelectedRoleStore();
       const customerId = selectedRoleStore.getCustomerIdSelected;
-      const description = null;
 
-      await teamService.createTeam(captainId, teamName, customerId, description);
+      await teamService.createTeam(
+        captainId,
+        teamName,
+        customerId,
+        teamDescription
+      );
     },
 
     /**

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -105,13 +105,6 @@ export const useTeamStore = defineStore("teamStore", {
       const customerId = selectedRoleStore.getCustomerIdSelected;
       const captainId = selectedRoleStore.getCaptainIdSelected;
 
-      console.log(
-        "teamStore: createTeam",
-        teamName,
-        teamDescription,
-        customerId,
-        captainId
-      );
       //the back handle if the captainId is null or not
       return await teamService.createTeam(
         captainId,
@@ -138,15 +131,6 @@ export const useTeamStore = defineStore("teamStore", {
       customerId: number | null,
       teamDescription: string | null
     ): Promise<TeamType> {
-      console.log(
-        "teamStore: updateTeam",
-        teamID,
-        cptId,
-        teamName,
-        customerId,
-        teamDescription
-      );
-
       return await teamService.updateTeam(
         teamID,
         cptId,

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -1,9 +1,9 @@
-import {TeamType} from "./../models/team.type";
-import {defineStore} from "pinia";
-import {teammateService} from "@/services/teammate.service";
-import {teamService} from "@/services/team.service";
-import {useSelectedRoleStore} from "@/stores/selectedRole";
-import {useTeammateStore} from "@/stores/teammateStore";
+import { TeamType } from "./../models/team.type";
+import { defineStore } from "pinia";
+import { teammateService } from "@/services/teammate.service";
+import { teamService } from "@/services/team.service";
+import { useSelectedRoleStore } from "@/stores/selectedRole";
+import { useTeammateStore } from "@/stores/teammateStore";
 
 interface State {
   teamList: TeamType[];
@@ -86,7 +86,7 @@ export const useTeamStore = defineStore("teamStore", {
     // add a selected user to a team
     async addUserToTeam(userId: number): Promise<void> {
       const teammateStore = useTeammateStore();
-      const data = {teamId: this.getTeamSelected.id, userId: userId};
+      const data = { teamId: this.getTeamSelected.id, userId: userId };
       await teammateService.createTeammate(data);
       await teammateStore.setListOfTeammatesWithinTeam(this.getTeamSelected.id);
     },
@@ -100,9 +100,15 @@ export const useTeamStore = defineStore("teamStore", {
       const selectedRoleStore = useSelectedRoleStore();
       const customerId = selectedRoleStore.getCustomerIdSelected;
       const captainId = selectedRoleStore.getCaptainIdSelected;
+      const description = null;
 
       //the back handle if the captainId is null or not
-      return await teamService.createTeam(captainId, teamName, customerId);
+      return await teamService.createTeam(
+        captainId,
+        teamName,
+        customerId,
+        description
+      );
     },
 
     /**
@@ -119,9 +125,16 @@ export const useTeamStore = defineStore("teamStore", {
       teamID: number,
       cptId: number | null,
       teamName: string | null,
-      customerId: number | null
+      customerId: number | null,
+      description: string | null
     ): Promise<TeamType> {
-      return await teamService.updateTeam(teamID, cptId, teamName, customerId);
+      return await teamService.updateTeam(
+        teamID,
+        cptId,
+        teamName,
+        customerId,
+        description
+      );
     },
 
     /**
@@ -140,11 +153,15 @@ export const useTeamStore = defineStore("teamStore", {
       this.captainIdToBeAssign = captainId;
     },
 
-    async createTeamOptionalAssignCaptain(teamName: string, captainId: number | null): Promise<void> {
+    async createTeamOptionalAssignCaptain(
+      teamName: string,
+      captainId: number | null
+    ): Promise<void> {
       const selectedRoleStore = useSelectedRoleStore();
       const customerId = selectedRoleStore.getCustomerIdSelected;
+      const description = null;
 
-      await teamService.createTeam(captainId, teamName, customerId);
+      await teamService.createTeam(captainId, teamName, customerId, description);
     },
 
     /**
@@ -154,7 +171,9 @@ export const useTeamStore = defineStore("teamStore", {
     async setTeamsFromCustomer() {
       const selectedRoleStore = useSelectedRoleStore();
 
-      this.teamList = await teamService.getAllTeamsByCustomerId(selectedRoleStore.customerIdSelected);
+      this.teamList = await teamService.getAllTeamsByCustomerId(
+        selectedRoleStore.customerIdSelected
+      );
     },
   },
 });

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/TeamModel.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/TeamModel.java
@@ -32,26 +32,26 @@ public class TeamModel {
     private int entityLogId;
 
     @Column(name = "team_description", nullable = true)
-    private String description;
+    private String teamDescription;
 
 
-    public TeamModel(List<CaptainModel> captainsModel, String teamName, int customerId, int entityLogId, String description) {
+    public TeamModel(List<CaptainModel> captainsModel, String teamName, int customerId, int entityLogId, String teamDescription) {
         this.captains = captainsModel;
         this.teamName = teamName;
         this.actif = true;
         this.customerId = customerId;
         this.entityLogId = entityLogId;
-        this.description = description;
+        this.teamDescription = teamDescription;
     }
 
-    public TeamModel(int id, List<CaptainModel> captainsModel, String teamName, int customerId, int entityLogId, String description) {
+    public TeamModel(int id, List<CaptainModel> captainsModel, String teamName, int customerId, int entityLogId, String teamDescription) {
         this.id = id;
         this.captains = captainsModel;
         this.teamName = teamName;
         this.actif = true;
         this.customerId = customerId;
         this.entityLogId = entityLogId;
-        this.description = description;
+        this.teamDescription = teamDescription;
     }
 
     public TeamModel() {
@@ -105,12 +105,12 @@ public class TeamModel {
         this.entityLogId = entityLogId;
     }
 
-    public String getDescription() {
-        return description;
+    public String getTeamDescription() {
+        return teamDescription;
     }
 
-    public void setDescription(String description) {
-        this.description = description;
+    public void setDescription(String teamDescription) {
+        this.teamDescription = teamDescription;
     }
 
     @Override

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
@@ -38,12 +38,12 @@ public class TeamServiceImpl implements TeamService {
 
         EntityLogModel entityLogModel = entityLogService.createEntityLog();
         final TeamModel teamModel = new TeamModel(captainModels, teamEntity.teamName(), teamEntity.customerId()
-                , entityLogModel.getId(), teamEntity.description());
+                , entityLogModel.getId(), teamEntity.teamDescription());
         teamJpaRepository.save(teamModel);
         //teamEntity.id could be null so we use autogenerate id
         List<Integer> captainsId = teamModel.getCaptains().stream()
                 .map(CaptainModel::getCaptainId).toList();
-        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getDescription());
+        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getTeamDescription());
 
     }
 
@@ -56,7 +56,7 @@ public class TeamServiceImpl implements TeamService {
         TeamModel teamModel = teamModelOpt.get();
         List<Integer> captainsId = teamModel.getCaptains().stream()
                 .map(CaptainModel::getCaptainId).toList();
-        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getDescription());
+        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getTeamDescription());
     }
 
     @Override
@@ -66,7 +66,7 @@ public class TeamServiceImpl implements TeamService {
             TeamModel teamModel = teamModelOpt.get();
             List<Integer> captainsId = teamModel.getCaptains().stream()
                     .map(captainModel -> captainModel.getCaptainId()).toList();
-            TeamEntity returnedEntity = new TeamEntity(id, captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getDescription());
+            TeamEntity returnedEntity = new TeamEntity(id, captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getTeamDescription());
             teamJpaRepository.deleteById(id);
             return returnedEntity;
         } else throw new EntityNotFoundException("The team with id " + id + " not found.");
@@ -89,13 +89,13 @@ public class TeamServiceImpl implements TeamService {
             if (entity.customerId() != null) {
                 teamModel.setCustomerId(entity.customerId());
             }
-            if (entity.description() != null) {
-                teamModel.setDescription(entity.description());
+            if (entity.teamDescription() != null) {
+                teamModel.setDescription(entity.teamDescription());
             }
             teamJpaRepository.save(teamModel);
             List<Integer> captainsId = teamModel.getCaptains().stream()
                     .map(CaptainModel::getCaptainId).toList();
-            return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getDescription());
+            return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getTeamDescription());
         } else {
             throw new EntityNotFoundException("Entity team with id " + id + " not found");
         }
@@ -110,7 +110,7 @@ public class TeamServiceImpl implements TeamService {
             if (!result.isActif()) continue; //if the Team has been deleted we don't return it
             List<Integer> captainsId = result.getCaptains().stream()
                     .map(CaptainModel::getCaptainId).toList();
-            TeamEntity teamEntity = new TeamEntity(result.getId(), captainsId, result.getTeamName(), result.getCustomerId(), result.getDescription());
+            TeamEntity teamEntity = new TeamEntity(result.getId(), captainsId, result.getTeamName(), result.getCustomerId(), result.getTeamDescription());
             teamEntities.add(teamEntity);
         }
         return teamEntities;
@@ -146,6 +146,6 @@ public class TeamServiceImpl implements TeamService {
         teamJpaRepository.save(teamModel);
         List<Integer> captainsId = teamModel.getCaptains().stream()
                 .map(CaptainModel::getCaptainId).toList();
-        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getDescription());
+        return new TeamEntity(teamModel.getId(), captainsId, teamModel.getTeamName(), teamModel.getCustomerId(), teamModel.getTeamDescription());
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeamEntity.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeamEntity.java
@@ -2,6 +2,7 @@ package com.xpeho.yaki_admin_backend.domain.entities;
 
 import java.util.List;
 
-public record TeamEntity(Integer id, List<Integer> captainsId, String teamName, Integer customerId, String description
+public record TeamEntity(Integer id, List<Integer> captainsId, String teamName, Integer customerId,
+                         String teamDescription
 ) {
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImplTests.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImplTests.java
@@ -116,7 +116,7 @@ class TeamServiceImplTests {
         //then
         String returnedResponse = objectMapper.writeValueAsString(teamDto);
         TeamEntity teamE3 = new TeamEntity(
-                idUsed, List.of(1), expectedModel.getTeamName(), 1, expectedModel.getDescription());
+                idUsed, List.of(1), expectedModel.getTeamName(), 1, expectedModel.getTeamDescription());
         String expectedResponse = objectMapper.writeValueAsString(teamE3);
         assertEquals(returnedResponse,
                 expectedResponse);
@@ -138,7 +138,7 @@ class TeamServiceImplTests {
         //then
         assertEquals(teamMateDeleted,
                 new TeamEntity(deletedModel.getId(),
-                        List.of(1), deletedModel.getTeamName(), 1, deletedModel.getDescription()));
+                        List.of(1), deletedModel.getTeamName(), 1, deletedModel.getTeamDescription()));
     }
 
     @Test

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamControllerTests.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamControllerTests.java
@@ -133,7 +133,7 @@ class TeamControllerTests {
     @Test
     void mustPutATeam() throws Exception {
         TeamEntity team3 = new TeamEntity(
-                2, TeamFeliz.captainsId(), TeamFeliz.teamName(), TeamFeliz.customerId(), TeamFeliz.description());
+                2, TeamFeliz.captainsId(), TeamFeliz.teamName(), TeamFeliz.customerId(), TeamFeliz.teamDescription());
 
         //given
         given(teamService.saveOrUpdate(TeamFeliz, 2)).willReturn(team3);

--- a/yaki_karate/src/test/resources/adminTeam.feature
+++ b/yaki_karate/src/test/resources/adminTeam.feature
@@ -2,7 +2,7 @@ Feature: Team
 
   Background:
     * url 'http://localhost:8080'
-    * def schema = {id : '#number', captainsId: '#array', teamName: '#string',customerId: '#number', description: '#string'}
+    * def schema = {id : '#number', captainsId: '#array', teamName: '#string',customerId: '#number', teamDescription: '#string'}
     Given path '/login/authenticate'
     And request { login: 'owner', password: 'owner' }
     When method post
@@ -62,7 +62,7 @@ Feature: Team
 
     Given path '/teams'
     And header Authorization = token
-    And request { captainsId : [2], teamName: "team_rocket", customerId: 2, description: "description team_rocket" }
+    And request { captainsId : [2], teamName: "team_rocket", customerId: 2, teamDescription: "description team_rocket" }
     When method post
     Then status 200
 
@@ -82,7 +82,7 @@ Feature: Team
 
     Given path '/teams/' + 1
     And header Authorization = token
-    And request {captainsId: [2], teamName: 'Team Red',customerId: 2, description: 'team is red'}
+    And request {captainsId: [2], teamName: 'Team Red',customerId: 2, teamDescription: 'team is red'}
     When method put
     Then status 200
     And match response == schema


### PR DESCRIPTION
# Description
What are changes related to ?

# Linked Issues
What are the issues fixed by this pull request ? [#736](https://github.com/XPEHO/YAKI/issues/736)

# Changes
The admin front has a team description field, so with bastiUI design a modal to create or edit it.

 DB:
create a migration script to update the team table and therefore add the description table.

 BACK :

teamModel: add the teamDescription attribute
use of the http://localhost:8080/teams/6 route
use saveOrUpdate service method
crud update
unit testing and karate testing

 front

You can add a description when creating the team and modify it


# Screenshots
Put screenshots (if any)

<img width="947" alt="image" src="https://github.com/XPEHO/YAKI/assets/96787811/0b1efff4-31c5-4276-9527-e2e2ea372d89">
<img width="687" alt="image" src="https://github.com/XPEHO/YAKI/assets/96787811/fac1c75b-d7f4-4d99-81d8-01e8e249f5e0">
<img width="944" alt="image" src="https://github.com/XPEHO/YAKI/assets/96787811/3cabb30b-ca84-4f1f-bb53-47867caf3c8d">


# Tests
How has it been tested ?

- [X] Manually
- [X] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
