### PR TITLE
fix(expired_token): add validity token check on application opening

### DIFF
--- a/yaki_backend/src/router.ts
+++ b/yaki_backend/src/router.ts
@@ -45,6 +45,10 @@ const passwordRepository = new PasswordRepository();
 const passwordService = new PasswordService(passwordRepository, userService);
 const passwordController = new PasswordController(passwordService);
 
+router.get("/verify-token", authService.verifyToken, (_, res) =>
+  res.status(200).send("Token is valid")
+);
+
 router.post("/login", signInLimiter, (req, res) =>
   /* #swagger.parameters['Login'] = {
                 in: 'body',
@@ -108,7 +112,8 @@ router.get(
                 schema: { userId: 1 }
 }
   */ authService.verifyToken(req, res, next),
-  async (req, res) => teammateController.getTeammatesDeclarationsAndAvatarFromUserTeams(req, res)
+  async (req, res) =>
+    teammateController.getTeammatesDeclarationsAndAvatarFromUserTeams(req, res)
 );
 
 // DEPRECIATED - TO BE REMOVED WHEN 1.10 isnt used anymore

--- a/yaki_mobile/lib/app_router.dart
+++ b/yaki_mobile/lib/app_router.dart
@@ -14,6 +14,7 @@ import 'package:yaki/presentation/features/user_declaration_summary/user_declara
 import 'package:yaki/presentation/features/team_selection/team_selection.dart';
 import 'package:yaki/presentation/features/user_declaration_summary/user_declaration_summary_absence.dart';
 import 'package:yaki/presentation/state/providers/declaration_provider.dart';
+import 'package:yaki/presentation/state/providers/token_provider.dart';
 import 'package:yaki/presentation/ui/default/user_default_redirection.dart';
 import 'package:yaki/presentation/features/password/forgot_password.dart';
 import 'package:yaki/presentation/features/password/change_password.dart';
@@ -31,7 +32,18 @@ final goRouterProvider = Provider<GoRouter>(
             // only redirect if we are on the Splash Screen
             if (state.fullPath == '/') {
               SharedPreferences prefs = await SharedPreferences.getInstance();
+
+              // check if the token is valid
+              await ref.read(tokenProvider.notifier).verifyTokenValidity();
+              final isJWTValid = ref.watch(tokenProvider);
+
+              if (!isJWTValid) {
+                prefs.remove('token');
+                return '/authentication';
+              }
+
               final declaration = ref.watch(declarationProvider);
+
               bool isLoggedIn = prefs.containsKey('token');
               final latestDeclarationStatus =
                   declaration.latestDeclarationStatus;
@@ -65,7 +77,9 @@ final goRouterProvider = Provider<GoRouter>(
                 child: Authentication(),
               ),
               redirect: (BuildContext context, GoRouterState state) async {
-                if (await SharedPref.isTokenPresent()) {
+                final isTokenSaves = await SharedPref.isTokenPresent();
+
+                if (isTokenSaves) {
                   return '/teams-declaration-summary';
                 } else {
                   return '/authentication';

--- a/yaki_mobile/lib/data/repositories/token_repository.dart
+++ b/yaki_mobile/lib/data/repositories/token_repository.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:yaki/data/sources/remote/token_api.dart';
+
+class TokenRepository {
+  final TokenApi _tokenApi;
+
+  TokenRepository(
+    this._tokenApi,
+  );
+
+  Future<bool> verifyTokenValidity() async {
+    bool isTokenValid = false;
+
+    try {
+      final getHttpResponse = await _tokenApi.verifyTokenValidity();
+      final statusCode = getHttpResponse.response.statusCode;
+
+      switch (statusCode) {
+        case 200:
+          isTokenValid = true;
+          break;
+        case 401:
+          isTokenValid = false;
+          break;
+        default:
+          throw Exception(
+            "Invalid statusCode : $statusCode",
+          );
+      }
+    } catch (err) {
+      debugPrint('error during verify token validity : $err');
+    }
+    return isTokenValid;
+  }
+}

--- a/yaki_mobile/lib/data/sources/remote/token_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/token_api.dart
@@ -1,0 +1,11 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+part 'token_api.g.dart';
+
+@RestApi()
+abstract class TokenApi {
+  factory TokenApi(Dio dio, {required String baseUrl}) = _TokenApi;
+
+  @GET('/verify-token')
+  Future<HttpResponse> verifyTokenValidity();
+}

--- a/yaki_mobile/lib/data/sources/remote/token_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/token_api.g.dart
@@ -1,0 +1,78 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'token_api.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _TokenApi implements TokenApi {
+  _TokenApi(
+    this._dio, {
+    this.baseUrl,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<HttpResponse<dynamic>> verifyTokenValidity() async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final Map<String, dynamic>? _data = null;
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/verify-token',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final value = _result.data;
+    final httpResponse = HttpResponse(value, _result);
+    return httpResponse;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/yaki_mobile/lib/presentation/state/notifiers/token_notifier.dart
+++ b/yaki_mobile/lib/presentation/state/notifiers/token_notifier.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yaki/data/repositories/token_repository.dart';
+
+class TokenNotifier extends StateNotifier<bool> {
+  final TokenRepository tokenRepository;
+
+  TokenNotifier({
+    required this.tokenRepository,
+  }) : super(false);
+
+  Future<void> verifyTokenValidity() async {
+    state = await tokenRepository.verifyTokenValidity();
+  }
+}

--- a/yaki_mobile/lib/presentation/state/providers/token_provider.dart
+++ b/yaki_mobile/lib/presentation/state/providers/token_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yaki/data/repositories/token_repository.dart';
+import 'package:yaki/data/sources/remote/token_api.dart';
+import 'package:yaki/presentation/state/dio/dio_interceptor.dart';
+import 'package:yaki/presentation/state/notifiers/token_notifier.dart';
+import 'package:yaki/presentation/state/providers/url_provider.dart';
+
+final tokenApiProvider = Provider(
+  (ref) => TokenApi(
+    ref.read(dioInterceptor),
+    baseUrl: ref.read(urlProvider),
+  ),
+);
+
+final tokenRepositoryProvider = Provider<TokenRepository>(
+  (ref) => TokenRepository(ref.read(tokenApiProvider)),
+);
+
+final tokenProvider = StateNotifierProvider<TokenNotifier, bool>(
+  (ref) => TokenNotifier(tokenRepository: ref.read(tokenRepositoryProvider)),
+);

--- a/yaki_mobile/pubspec.lock
+++ b/yaki_mobile/pubspec.lock
@@ -1267,5 +1267,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=3.13.0"


### PR DESCRIPTION
# Description
What are changes related to ?

Add a token validation end point, in the back end, and on opening the mobile application the registered token will be verify to then connect or not.
This will prevent to have the user be redirected and locked on others pages as the token will not permit any further action or informations fetch.

# Linked Issues
What are the issues fixed by this pull request ?
#1176 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
