### PR TITLE
feat(credential_navigation): verify user credential to lock or unlock admin functionalities

### DIFF
--- a/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
+++ b/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
@@ -32,12 +32,22 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  isUserAutorized: {
+    type: Boolean,
+    default: false,
+  },
 });
 </script>
 
 <template>
-  <section class="drop-down__container">
-    <div class="text-icon__container text-icon__container-height--padding text_icon--icon drop-down--sidebar-color">
+  <section :class="['drop-down__container', isUserAutorized ? '' : 'menu-drop-down-disable']">
+    <div
+      :class="[
+        'text-icon__container',
+        'text-icon__container-height--padding',
+        'text_icon--icon',
+        isUserAutorized ? 'drop-down--sidebar-color' : '',
+      ]">
       <figure>
         <img
           :src="groupIcon"
@@ -45,15 +55,22 @@ const props = defineProps({
       </figure>
       <p class="text-icon--text">{{ props.innerText }}</p>
     </div>
+
+    <!-- AUTORIZATION -->
     <input
       class="drop-down__checkbox"
       type="checkbox"
-      id="sidebar-dropdown" />
-    <figure class="drop-down__icon">
+      id="sidebar-dropdown"
+      :disabled="!isUserAutorized" />
+    <!-- AUTORIZATION -->
+    <figure
+      v-if="isUserAutorized"
+      class="drop-down__icon image-filter">
       <img
         :src="arrowIcon"
         alt="drop down menu arrow" />
     </figure>
+
     <section class="drop-down__menu">
       <button
         @click.prevent="onClickAddTeam"
@@ -134,6 +151,22 @@ const props = defineProps({
 
   &:active {
     transform: scale(0.99) translateY(1px);
+  }
+}
+
+.menu-drop-down-disable {
+  figure {
+    img {
+      filter: invert(0.8) brightness(0.5);
+    }
+  }
+
+  p {
+    color: rgb(113, 104, 104);
+  }
+
+  input {
+    cursor: default;
   }
 }
 </style>

--- a/yaki_admin/src/ui/components/sidebar/SideBarMenuLink.vue
+++ b/yaki_admin/src/ui/components/sidebar/SideBarMenuLink.vue
@@ -18,6 +18,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  isUserAutorized: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const defaultClassList = [
@@ -29,7 +33,16 @@ const defaultClassList = [
 </script>
 
 <template>
-  <div :class="[defaultClassList, isModalElement ? 'text-icon--background-white' : 'text-icon--sidebar-color']">
+  <div
+    :class="[
+      defaultClassList,
+      isModalElement
+        ? 'text-icon--background-white'
+        : isUserAutorized
+        ? 'text-icon--sidebar-color'
+        : '',
+      isUserAutorized ? '' : 'menu-link-disable',
+    ]">
     <figure>
       <img
         :src="icon"
@@ -38,3 +51,19 @@ const defaultClassList = [
     <p class="text-icon--text">{{ props.text }}</p>
   </div>
 </template>
+
+<style scoped lang="scss">
+.menu-link-disable {
+  figure {
+    img {
+      filter: invert(0.8) brightness(0.5);
+    }
+  }
+
+  p {
+    color: rgb(113, 104, 104);
+  }
+
+  cursor: default;
+}
+</style>

--- a/yaki_admin/src/ui/views/SideBarContent.vue
+++ b/yaki_admin/src/ui/views/SideBarContent.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import router from "@/router/router";
+import {onMounted, reactive} from "vue";
+import {useRoleStore} from "@/stores/roleStore";
+
 import SideBarMenuLink from "@/ui/components/sidebar/SideBarMenuLink.vue";
 import sideBarMenuDropDown from "@/ui/components/sidebar/SideBarMenuDropDown.vue";
 import LoggedUserCard from "@/ui/components/LoggedUserCard.vue";
@@ -8,10 +12,28 @@ import caseIcon from "@/assets/images/briefcase-regular-24.png";
 import hatIcon from "@/assets/images/hard-hat-regular-24.png";
 import statIcon from "@/assets/images/stats.png";
 
-import router from "@/router/router";
+const roleStoreTest = useRoleStore();
 
-const onClickStatistics = () => {
-  router.push("/dashboard/statistics");
+const userCredentials = reactive({
+  owner: false as boolean,
+  customer: false as boolean,
+  captain: false as boolean,
+});
+
+onMounted(() => {
+  userCredentials.customer = roleStoreTest.customersIdWhereIgotRights.length > 0;
+  userCredentials.captain = roleStoreTest.captainsId.length > 0;
+});
+
+const redirection = (path: string) => {
+  if (path.includes("statistics")) {
+    router.push("/dashboard/statistics");
+    return;
+  }
+  if (path.includes("manage-captains") && userCredentials.customer) {
+    router.push("/dashboard/manage-captains");
+    return;
+  }
 };
 </script>
 
@@ -19,14 +41,27 @@ const onClickStatistics = () => {
   <nav class="sidebar__container">
     <div>
       <figure>
-        <img :src="Banner" alt="" />
+        <img
+          :src="Banner"
+          alt="" />
       </figure>
 
-      <side-bar-menu-link :icon="caseIcon" text="Clients" />
-      <side-bar-menu-link :icon="hatIcon" text="Captains" />
-      <side-bar-menu-drop-down inner-text="My teams" icon-path="groupIcon" />
       <side-bar-menu-link
-        @click.prevent="onClickStatistics"
+        :is-user-autorized="userCredentials.owner"
+        :icon="caseIcon"
+        text="Clients" />
+      <side-bar-menu-link
+        :is-user-autorized="userCredentials.customer"
+        @click.prevent="redirection('/dashboard/manage-captains')"
+        :icon="hatIcon"
+        text="Captains" />
+      <side-bar-menu-drop-down
+        :is-user-autorized="userCredentials.captain"
+        inner-text="My teams"
+        icon-path="groupIcon" />
+      <side-bar-menu-link
+        :is-user-autorized="true"
+        @click.prevent="redirection('/dashboard/statistics')"
         :icon="statIcon"
         text="Statistics" />
     </div>


### PR DESCRIPTION
# Description
What are changes related to ?

Add user credential check to authorize or not the accessibility to differents functionalities of the website.
Locked functionalities are not selectable or clickable.

# Linked Issues
What are the issues fixed by this pull request ?
#1109

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="328" alt="Capture d’écran 2024-01-03 à 09 15 30" src="https://github.com/XPEHO/YAKI/assets/95299697/30ff79d6-3a62-4fb7-a84b-c00af73f9d7b">
<img width="360" alt="Capture d’écran 2024-01-03 à 09 15 49" src="https://github.com/XPEHO/YAKI/assets/95299697/76a84f9e-fe8b-41f3-a7b2-355f1fb35d7b">


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
