### PR TITLE
fix(admin_front): prevent first team of the list to always be selected at page change

### DIFF
--- a/yaki_admin/src/ui/views/TeamManagementView.vue
+++ b/yaki_admin/src/ui/views/TeamManagementView.vue
@@ -13,7 +13,11 @@ const teamStore = useTeamStore();
 //before mount, select first team from fetched team list (fetched in the router the first time the user connect)
 onBeforeMount(async () => {
   // automaticaly select first team right after team fetch on component mount ( right after the first connexion)
-  if (teamStore.getTeamList && teamStore.getTeamList.length > 0) {
+  if (
+    (teamStore.getTeamSelected.id === null || teamStore.getTeamSelected.id === undefined) &&
+    teamStore.getTeamList &&
+    teamStore.getTeamList.length > 0
+  ) {
     teamStore.setTeamInfoAndFetchTeammates(teamStore.getTeamList[0]);
   }
 });


### PR DESCRIPTION
# Description
What are changes related to ?

prevent on page content change to have the first team being selected when selecting a team to go back on the management team part

# Linked Issues
What are the issues fixed by this pull request ?
#1191 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
