### PR TITLE
feat(team_logo): admin back create endpoint to save and get team logo

### DIFF
--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/TeamLogoModel.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/models/TeamLogoModel.java
@@ -1,0 +1,74 @@
+package com.xpeho.yaki_admin_backend.data.models;
+
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "team_logo", schema = "public")
+public class TeamLogoModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "team_logo_seq")
+    @SequenceGenerator(name = "team_logo_seq", sequenceName = "team_logo_id_seq", allocationSize = 1)
+    @Column(name = "team_logo_id")
+    private int teamLogoId;
+
+    @Column(name = "team_logo_team_id")
+    private int teamLogoTeamId;
+
+    @Column(name = "team_logo_blob")
+    private byte[] teamLogoBlob;
+
+    public TeamLogoModel() {
+    }
+
+    public TeamLogoModel(int teamLogoTeamId, byte[] teamLogoBlob) {
+        this.teamLogoTeamId = teamLogoTeamId;
+        this.teamLogoBlob = teamLogoBlob;
+    }
+
+    public int getTeamLogoId() {
+        return this.teamLogoId;
+    }
+
+    public void setTeamLogoId(int teamLogoId) {
+        this.teamLogoId = teamLogoId;
+    }
+
+    public int getTeamLogoTeamId() {
+        return this.teamLogoTeamId;
+    }
+
+    public void setTeamLogoTeamId(int teamLogoTeamId) {
+        this.teamLogoTeamId = teamLogoTeamId;
+    }
+
+    public byte[] getTeamLogoBlob() {
+        return this.teamLogoBlob;
+    }
+
+    public void setTeamLogoBlob(byte[] teamLogoBlob) {
+        this.teamLogoBlob = teamLogoBlob;
+    }
+
+    public TeamLogoEntity toEntity() {
+        TeamLogoEntity entity = new TeamLogoEntity(this.teamLogoTeamId, this.teamLogoBlob);
+        return entity;
+    }
+
+    @Override
+    public boolean equals(Object currentInstance) {
+        if (currentInstance == this)
+            return true;
+        if (!(currentInstance instanceof TeamLogoModel)) {
+            return false;
+        }
+        TeamLogoModel teamLogoModel = (TeamLogoModel) currentInstance;
+        return teamLogoId == teamLogoModel.teamLogoId && teamLogoTeamId == teamLogoModel.teamLogoTeamId && java.util.Arrays.equals(teamLogoBlob, teamLogoModel.teamLogoBlob);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(teamLogoId, teamLogoTeamId, teamLogoBlob);
+    }
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
@@ -1,0 +1,68 @@
+package com.xpeho.yaki_admin_backend.data.services;
+
+import com.xpeho.yaki_admin_backend.data.models.TeamLogoModel;
+import com.xpeho.yaki_admin_backend.data.sources.TeamLogoRepository;
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+import com.xpeho.yaki_admin_backend.domain.services.TeamLogoService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class TeamLogoServiceImpl implements TeamLogoService {
+    final TeamLogoRepository teamLogoRepository;
+
+    public TeamLogoServiceImpl(TeamLogoRepository teamLogoRepository) {
+        this.teamLogoRepository = teamLogoRepository;
+    }
+
+    public TeamLogoEntity getTeamLogoByTeamId(int teamId) {
+        Optional<TeamLogoModel> OptionalTeamLogoModel = teamLogoRepository.findOptionalByTeamLogoTeamId(teamId);
+
+        if (OptionalTeamLogoModel.isPresent()) {
+            TeamLogoModel teamLogoModel = OptionalTeamLogoModel.get();
+
+            return teamLogoModel.toEntity();
+        } else {
+            throw new EntityNotFoundException("Team logo not found");
+        }
+    }
+
+    @Override
+    public TeamLogoEntity save(TeamLogoEntity teamLogoEntity) {
+        final TeamLogoModel teamLogoModel = new TeamLogoModel(
+                teamLogoEntity.teamId(),
+                teamLogoEntity.teamLogoBlob()
+        );
+        TeamLogoModel createdTeamLogo = teamLogoRepository.save(teamLogoModel);
+
+        return createdTeamLogo.toEntity();
+    }
+
+    public TeamLogoEntity createOrUpdateByTeamId(int teamId, byte[] teamLogoBlob) {
+        Optional<TeamLogoModel> OptinalTeamLogoModel = teamLogoRepository.findOptionalByTeamLogoTeamId(teamId);
+
+        if (OptinalTeamLogoModel.isPresent()) {
+
+            TeamLogoModel teamLogoModelToUpdate = OptinalTeamLogoModel.get();
+            teamLogoModelToUpdate.setTeamLogoBlob(teamLogoBlob);
+            TeamLogoModel updated = teamLogoRepository.save(teamLogoModelToUpdate);
+            return updated.toEntity();
+        } else {
+            return this.save(new TeamLogoEntity(teamId, teamLogoBlob));
+        }
+    }
+
+    public TeamLogoEntity deleteByTeamId(int teamId) {
+        Optional<TeamLogoModel> OptinalTeamLogoModel = teamLogoRepository.findOptionalByTeamLogoTeamId(teamId);
+
+        if (OptinalTeamLogoModel.isPresent()) {
+            TeamLogoModel teamLogoModelToDelete = OptinalTeamLogoModel.get();
+            teamLogoRepository.delete(teamLogoModelToDelete);
+            return teamLogoModelToDelete.toEntity();
+        } else {
+            throw new EntityNotFoundException("Team logo not found");
+        }
+    }
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
@@ -22,13 +22,19 @@ public class TeamServiceImpl implements TeamService {
     final CaptainServiceImpl captainService;
     final CaptainsTeamsServiceImpl captainsTeamsService;
     final EntityLogServiceImpl entityLogService;
+    final TeamLogoServiceImpl teamLogoService;
 
-    public TeamServiceImpl(TeamJpaRepository teamJpaRepository, CaptainServiceImpl captainService, CaptainsTeamsServiceImpl captainsTeamsService, EntityLogServiceImpl entityLogService) {
+    public TeamServiceImpl(TeamJpaRepository teamJpaRepository,
+                           CaptainServiceImpl captainService,
+                           CaptainsTeamsServiceImpl captainsTeamsService,
+                           EntityLogServiceImpl entityLogService,
+                           TeamLogoServiceImpl teamLogoService
+    ) {
         this.teamJpaRepository = teamJpaRepository;
         this.captainService = captainService;
         this.captainsTeamsService = captainsTeamsService;
         this.entityLogService = entityLogService;
-
+        this.teamLogoService = teamLogoService;
     }
 
     @Override
@@ -137,6 +143,9 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public TeamEntity disabled(int teamId) {
         Optional<TeamModel> teamModelOpt = teamJpaRepository.findById(teamId);
+        // delete logo rown when disable team
+        teamLogoService.deleteByTeamId(teamId);
+
         if (teamModelOpt.isEmpty()) {
             throw new EntityNotFoundException("The team with id " + teamId + " not found.");
         }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/sources/TeamLogoRepository.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/sources/TeamLogoRepository.java
@@ -1,0 +1,11 @@
+package com.xpeho.yaki_admin_backend.data.sources;
+
+import com.xpeho.yaki_admin_backend.data.models.TeamLogoModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamLogoRepository extends JpaRepository<TeamLogoModel, Integer> {
+    Optional<TeamLogoModel> findOptionalByTeamLogoTeamId(int id);
+    TeamLogoModel findByTeamLogoTeamId(int id);
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeamLogoEntity.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/entities/TeamLogoEntity.java
@@ -1,0 +1,4 @@
+package com.xpeho.yaki_admin_backend.domain.entities;
+
+public record TeamLogoEntity(int teamId, byte[] teamLogoBlob) {
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/TeamLogoService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/TeamLogoService.java
@@ -1,0 +1,12 @@
+package com.xpeho.yaki_admin_backend.domain.services;
+
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+
+public interface TeamLogoService {
+    TeamLogoEntity getTeamLogoByTeamId(int id);
+    TeamLogoEntity save(TeamLogoEntity teamLogoEntity);
+
+    TeamLogoEntity createOrUpdateByTeamId(int id, byte[] teamLogoBlob);
+
+    TeamLogoEntity deleteByTeamId(int id);
+}

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamController.java
@@ -5,6 +5,7 @@ import com.xpeho.yaki_admin_backend.domain.entities.TeamEntityWithCaptainsDetail
 import com.xpeho.yaki_admin_backend.domain.services.TeamService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -54,4 +55,6 @@ public class TeamController {
     public TeamEntity disabled(@PathVariable int id) {
         return teamService.disabled(id);
     }
+
+
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoController.java
@@ -1,0 +1,44 @@
+package com.xpeho.yaki_admin_backend.presentation.controllers;
+
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+import com.xpeho.yaki_admin_backend.domain.services.TeamLogoService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/teams/{id}/logo")
+@SecurityRequirement(name = "bearerAuth")
+public class TeamLogoController {
+    final TeamLogoService teamLogoService;
+
+    public TeamLogoController(TeamLogoService teamLogoService) {
+        this.teamLogoService = teamLogoService;
+    }
+
+    @GetMapping()
+    public TeamLogoEntity getTeamLogoByTeamId(@PathVariable int id) {
+        return teamLogoService.getTeamLogoByTeamId(id);
+    }
+
+    @PutMapping()
+    public TeamLogoEntity createOrUpdateByTeamId(@PathVariable int id, @RequestParam("file") MultipartFile file) {
+        try {
+            byte[] bytes = file.getBytes();
+
+            return teamLogoService.createOrUpdateByTeamId(id, bytes);
+        } catch (Exception e) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred while creating or updating the team logo.", e);
+        }
+    }
+
+    @DeleteMapping()
+    public TeamLogoEntity deleteByTeamId(@PathVariable int id) {
+        return teamLogoService.deleteByTeamId(id);
+    }
+
+}

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/LocationServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/LocationServiceImplTest.java
@@ -3,13 +3,10 @@ package com.xpeho.yaki_admin_backend.data.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xpeho.yaki_admin_backend.data.models.EntityLogModel;
 import com.xpeho.yaki_admin_backend.data.models.LocationModel;
-import com.xpeho.yaki_admin_backend.data.sources.EntityLogJpaRepository;
 import com.xpeho.yaki_admin_backend.data.sources.LocationRepository;
 import com.xpeho.yaki_admin_backend.domain.entities.LocationEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -19,8 +16,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImplTest.java
@@ -1,0 +1,97 @@
+package com.xpeho.yaki_admin_backend.data.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xpeho.yaki_admin_backend.data.models.TeamLogoModel;
+import com.xpeho.yaki_admin_backend.data.sources.TeamLogoRepository;
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+public class TeamLogoServiceImplTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockBean
+    private TeamLogoRepository teamLogoRepository;
+
+    @Autowired
+    private TeamLogoServiceImpl teamLogoService;
+
+    private TeamLogoModel teamLogoModel1;
+    private TeamLogoModel teamLogoModel2;
+
+    private TeamLogoEntity teamLogoEntity1;
+    private TeamLogoEntity teamLogoEntity2;
+
+    @BeforeEach
+    void setup() {
+        byte[] logoBlob1 = new byte[]{1, 2, 3, 4, 5};
+        byte[] logoBlob2 = new byte[]{1, 2, 3, 4, 5};
+
+        teamLogoModel1 = new TeamLogoModel(1, logoBlob1);
+        teamLogoModel2 = new TeamLogoModel(2, logoBlob2);
+
+        teamLogoEntity1 = new TeamLogoEntity(1, logoBlob1);
+        teamLogoEntity2 = new TeamLogoEntity(2, logoBlob2);
+    }
+
+    @Test
+    public void getTeamLogos() {
+        // given
+        byte[] logoBlob = new byte[]{1, 2, 3, 4, 5};
+        TeamLogoEntity teamLogoEntity1 = new TeamLogoEntity(1, logoBlob);
+        // ... set other properties of teamLogoEntity1
+        given(teamLogoRepository.findOptionalByTeamLogoTeamId(1)).willReturn(Optional.of(teamLogoModel1));
+        // when
+        TeamLogoEntity teamLogoEntity = teamLogoService.getTeamLogoByTeamId(1);
+        // then
+        // Arrays.equals() is used to compare array content and not their adress in memory
+        assertTrue(Arrays.equals(teamLogoEntity.teamLogoBlob(), teamLogoEntity1.teamLogoBlob()));
+    }
+
+    @Test
+    public void createTeamLogo() {
+        // given
+        byte[] logoBlob = new byte[]{1, 2, 3, 4, 5};
+        TeamLogoEntity teamLogoEntityToSave = new TeamLogoEntity(1, logoBlob);
+        TeamLogoModel teamLogoModelToSave = new TeamLogoModel(1, logoBlob);
+        given(teamLogoRepository.save(teamLogoModelToSave)).willReturn(teamLogoModel1);
+        // when
+        TeamLogoEntity teamLogoEntity = teamLogoService.save(teamLogoEntityToSave);
+        // then
+        assertThat(teamLogoEntity.teamId(), is(equalTo(teamLogoEntityToSave.teamId())));
+        assertTrue(Arrays.equals(teamLogoEntity.teamLogoBlob(), teamLogoEntityToSave.teamLogoBlob()));
+    }
+
+    @Test
+    public void deleteByTeamId() {
+        // given
+        byte[] logoBlob = new byte[]{1, 2, 3, 4, 5};
+        TeamLogoEntity teamLogoEntityToDelete = new TeamLogoEntity(1, logoBlob);
+        TeamLogoModel teamLogoModelToDelete = new TeamLogoModel(1, logoBlob);
+        given(teamLogoRepository.findOptionalByTeamLogoTeamId(1)).willReturn(Optional.of(teamLogoModel1));
+        // when
+        TeamLogoEntity teamLogoEntity = teamLogoService.deleteByTeamId(1);
+        // then
+        assertThat(teamLogoEntity.teamId(), is(equalTo(teamLogoEntityToDelete.teamId())));
+        assertTrue(Arrays.equals(teamLogoEntity.teamLogoBlob(), teamLogoEntityToDelete.teamLogoBlob()));
+    }
+
+}

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoControllerTests.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoControllerTests.java
@@ -1,0 +1,104 @@
+package com.xpeho.yaki_admin_backend.presentation.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xpeho.yaki_admin_backend.data.models.TeamLogoModel;
+import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
+import com.xpeho.yaki_admin_backend.domain.services.TeamLogoService;
+import com.xpeho.yaki_admin_backend.error_handling.CustomExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TeamLogoControllerTests {
+    private MockMvc mvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private TeamLogoService teamLogoService;
+
+    @InjectMocks
+    private TeamLogoController teamLogoController;
+
+    @BeforeEach
+    public void setup() {
+        mvc = MockMvcBuilders.standaloneSetup(teamLogoController)
+                .setControllerAdvice(new CustomExceptionHandler())
+                .build();
+    }
+
+    private byte[] logoBlob = new byte[]{1, 2, 3, 4, 5};
+    TeamLogoModel teamLogoModel = new TeamLogoModel(1, logoBlob);
+    TeamLogoEntity teamLogoEntity = new TeamLogoEntity(1, logoBlob);
+
+
+    @Test
+    public void shouldReturnTeamLogoByTeamId() throws Exception {
+
+        given(teamLogoService.getTeamLogoByTeamId(1)).willReturn(teamLogoEntity);
+
+        MockHttpServletResponse response = mvc.perform(
+                        MockMvcRequestBuilders.get("/teams/1/logo")
+                                .accept(MediaType.APPLICATION_JSON))
+                .andReturn()
+                .getResponse();
+
+        assertThat(response.getStatus(), is(equalTo(HttpStatus.OK.value())));
+        String expectedResponse = objectMapper.writeValueAsString(teamLogoEntity);
+        assertThat(response.getContentAsString(), is(equalTo(
+                expectedResponse)));
+    }
+
+    @Test
+    public void shouldCreateOrUpdateTeamLogoByTeamId() throws Exception {
+        int teamId = 1;
+        byte[] content = "image-content".getBytes();
+        MultipartFile multipartFile = new MockMultipartFile("file", "image.jpeg", "text/plain", content);
+
+        TeamLogoEntity expectedEntity = new TeamLogoEntity(teamId, content);
+        given(teamLogoService.createOrUpdateByTeamId(teamId, content)).willReturn(expectedEntity);
+
+        TeamLogoEntity resultEntity = teamLogoController.createOrUpdateByTeamId(teamId, multipartFile);
+
+        assertArrayEquals(expectedEntity.teamLogoBlob(), resultEntity.teamLogoBlob());
+        verify(teamLogoService, times(1)).createOrUpdateByTeamId(teamId, content);
+    }
+
+    @Test
+    public void shouldDeleteTeamLogoByTeamId() throws Exception {
+
+        given(teamLogoService.deleteByTeamId(1)).willReturn(teamLogoEntity);
+
+        MockHttpServletResponse response = mvc.perform(
+                        MockMvcRequestBuilders.delete("/teams/1/logo")
+                                .accept(MediaType.APPLICATION_JSON))
+                .andReturn()
+                .getResponse();
+
+        assertThat(response.getStatus(), is(equalTo(HttpStatus.OK.value())));
+        String expectedResponse = objectMapper.writeValueAsString(teamLogoEntity);
+        assertThat(response.getContentAsString(), is(equalTo(
+                expectedResponse)));
+    }
+}
+

--- a/yaki_backend/src/db/create_tables.sql
+++ b/yaki_backend/src/db/create_tables.sql
@@ -78,6 +78,15 @@ CREATE SEQUENCE IF NOT EXISTS public.team_id_seq
     CACHE 1;
 ALTER SEQUENCE public.team_id_seq
     OWNER TO yaki;
+-- CREATE TEAMLOGO IDs
+CREATE SEQUENCE IF NOT EXISTS public.team_logo_id_seq
+    INCREMENT 1
+    START 1
+    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+ALTER SEQUENCE public.team_logo_id_seq
+    OWNER TO yaki;    
 -- CREATE TEAM MATE IDs
 CREATE SEQUENCE IF NOT EXISTS public.teammate_id_seq
     INCREMENT 1
@@ -399,3 +408,13 @@ ALTER TABLE public.locations
 ADD COLUMN IF NOT EXISTS location_entity_log_id integer DEFAULT 1;
 ALTER TABLE public.locations
 ADD COLUMN IF NOT EXISTS location_is_active boolean NOT NULL DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS public.team_logo(
+    team_logo_id integer NOT NULL DEFAULT nextval('public.team_logo_id_seq'::regclass),
+    team_logo_team_id integer NOT NULL,
+    team_logo_blob bytea,
+    CONSTRAINT team_logo_pkey PRIMARY KEY (team_logo_id)
+)
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS public.team_logo
+    OWNER to yaki;


### PR DESCRIPTION
# Description
What are changes related to ?

Add appropriate SQL script migration script.
Create CRUD to handled team logo in the springboot backend.
Add a getByTeamId
Add a saveOrUpdate, each team will only use one team logo row in the database
Add a delete teamLogo for when the team is disabled.

# Linked Issues
What are the issues fixed by this pull request ?
#1205

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [x] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
