### PR TITLE
feat(team_logo): admin back create endpoint to save and get team logo (#1215)

### DIFF
--- a/yaki_admin/src/composable/userFilePicker.ts
+++ b/yaki_admin/src/composable/userFilePicker.ts
@@ -1,0 +1,84 @@
+import { MODALMODE } from "@/constants/modalMode.enum";
+import { setTeamLogoUrl } from "@/utils/images.utils";
+import teamImage from "@/assets/images/teamDefaultImg2.svg";
+import { ref } from "vue";
+import { useTeamStore } from "@/stores/teamStore";
+
+/**
+ * Composition function handling the file picker.
+ *
+ * This function is responsible for handling the user's file input.
+ *
+ * @returns {Object} An object containing the following properties:
+ * - logoSrc: ref holding the source URL of image. Initially set to a default image.
+ * - isLogoToHeavy: ref indicating whether the selected file is too large (> 500KB), use in component to display a warning message.
+ * - selectedFile: ref holding the selected File object.
+ * - openFilePicker: A function that triggers the file input click event to open the file picker dialog.
+ * - handleFileSelected: A function that handles the file input change event.
+ * - setTeamLogo: A function that sets the team logo URL based on the current team selected logo.
+ */
+export function userFilePicker() {
+  const teamStore = useTeamStore();
+
+  // file handling
+
+  const selectedFile = ref<File | null>(null);
+  const logoSrc = ref(teamImage);
+  const isLogoToHeavy = ref(false);
+
+  const setTeamLogo = (newIsShow: boolean, newMode: MODALMODE) => {
+    if (!newIsShow || (newMode !== MODALMODE.teamEdit && newMode !== MODALMODE.teamCreate)) {
+      return;
+    }
+    const currentLogo = teamStore.getTeamSelectedLogo;
+
+    logoSrc.value = setTeamLogoUrl(currentLogo.teamLogoBlob);
+  };
+
+  /**
+   * Handle the file input change event.
+   *
+   * Is triggered when a file is selected in the file input element.
+   * Checks if any file has been selected.
+   * Then, it checks for a size limit. If it goes over the limit set `isLogoToHeavy` to true and returns.
+   * Else creates a new FileReader object to read the file content and assigne it to the selecteFile ref used to display the image.
+   *
+   * @param event - The event object associated with the file input change event.
+   * @returns void
+   */
+  const handleFileSelected = async (event: Event) => {
+    const target = event.target as HTMLInputElement;
+
+    if (target.files) {
+      const file = target.files[0];
+      selectedFile.value = file;
+
+      if (file.size > 500000) {
+        isLogoToHeavy.value = true;
+        return;
+      }
+
+      // Object async read files (raw data or buffer)
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        // triggered when the read operation is finished, and apply the reader.result to the avatarSrc
+        logoSrc.value = reader.result as string;
+      };
+      // read the blob or file content as a base64 encoded string
+      reader.readAsDataURL(selectedFile.value);
+    }
+  };
+
+  const setDefaultLogo = () => {
+    logoSrc.value = teamImage;
+  };
+
+  return {
+    logoSrc,
+    isLogoToHeavy,
+    selectedFile,
+    handleFileSelected,
+    setTeamLogo,
+    setDefaultLogo,
+  };
+}

--- a/yaki_admin/src/features/invitation/components/InvitationViewHeader.vue
+++ b/yaki_admin/src/features/invitation/components/InvitationViewHeader.vue
@@ -9,7 +9,7 @@ import { INVITEDROLE } from "@/constants/pathParam.enum";
 
 const teamStore = useTeamStore();
 
-const props = defineProps({
+defineProps({
   /**
    * Role of the invited user,
    * used to display the correct title.

--- a/yaki_admin/src/models/TeamLogo.type.ts
+++ b/yaki_admin/src/models/TeamLogo.type.ts
@@ -1,0 +1,4 @@
+export type TeamLogoType = {
+  teamId: number;
+  teamLogoBlob: Uint8Array | null;
+};

--- a/yaki_admin/src/services/teamLogo.service.ts
+++ b/yaki_admin/src/services/teamLogo.service.ts
@@ -1,0 +1,45 @@
+import { environmentVar } from "@/envPlaceholder";
+import { TeamLogoType } from "@/models/TeamLogo.type";
+import { useAuthStore } from "@/stores/authStore";
+import { authHeader } from "@/utils/authUtils";
+import { handleResponse } from "@/utils/responseUtils";
+
+const URL: string = environmentVar.baseURL;
+
+class TeamLogoService {
+  getTeamLogo = async (teamId: number): Promise<TeamLogoType> => {
+    const requestOptions = {
+      method: "GET",
+      headers: authHeader(`${URL}/teams/${teamId}/logo`),
+    };
+
+    const response = await fetch(`${URL}/teams/${teamId}/logo`, requestOptions)
+      .then(handleResponse)
+      .catch((err) => console.warn(err));
+
+    return response;
+  };
+
+  createOrUpdateTeamLogo = async (teamId: number, logo: File): Promise<TeamLogoType> => {
+    const formData = new FormData();
+    formData.append("file", logo);
+
+    const { user } = useAuthStore();
+
+    const requestOptions = {
+      method: "PUT",
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+      },
+    };
+
+    const response = await fetch(`${URL}/teams/${teamId}/logo`, requestOptions)
+      .then(handleResponse)
+      .catch((err) => console.warn(err));
+
+    return response;
+  };
+}
+
+export const teamLogoService = Object.freeze(new TeamLogoService());

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -78,6 +78,7 @@ export const useModalStore = defineStore("userModalStore", {
 
     /**
      * Modal action management :
+     * Invoked in ModalFrameView, when user click on "validation" button in modal
      * Trigger corresponding methods depending on the current modal mode set when invoking switchModalVisibility.
      * See MODALMODE enum for more information
      *

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -4,11 +4,14 @@ import { teammateService } from "@/services/teammate.service";
 import { teamService } from "@/services/team.service";
 import { useSelectedRoleStore } from "@/stores/selectedRole";
 import { useTeammateStore } from "@/stores/teammateStore";
+import { teamLogoService } from "@/services/teamLogo.service";
+import { TeamLogoType } from "@/models/TeamLogo.type";
 
 interface State {
   teamList: TeamType[];
   isTeamListSetOnLoggin: boolean;
   teamSelected: TeamType;
+  teamSelectedLogo: TeamLogoType;
   teamDeleted: TeamType;
   captainIdToBeAssign: number | null;
 }
@@ -20,6 +23,8 @@ export const useTeamStore = defineStore("teamStore", {
     // This way the router will not trigger fetch everytime the user navigate to the captain page.
     isTeamListSetOnLoggin: false as boolean,
     teamSelected: {} as TeamType,
+    teamSelectedLogo: { teamId: 0, teamLogoBlob: null } as TeamLogoType,
+
     teamDeleted: {} as TeamType,
 
     // DEPRECIATED WITH BASTI CHANGE ? ------------------------------------
@@ -30,6 +35,7 @@ export const useTeamStore = defineStore("teamStore", {
     getTeamList: (state: State) => state.teamList,
     getIsTeamListSetOnLoggin: (state: State) => state.isTeamListSetOnLoggin,
     getTeamSelected: (state: State) => state.teamSelected,
+    getTeamSelectedLogo: (state: State) => state.teamSelectedLogo,
     getTeamDeleted: (state: State) => state.teamDeleted,
 
     // DEPRECIATED WITH BASTI CHANGE ? ------------------------------------
@@ -52,6 +58,7 @@ export const useTeamStore = defineStore("teamStore", {
       return false;
     },
 
+    // Move this methide to the teammateStore ?
     /**
      * save team info in the store (teamSelected)
      * And trigger the team's teammates fetch.
@@ -59,9 +66,15 @@ export const useTeamStore = defineStore("teamStore", {
      */
     async setTeamInfoAndFetchTeammates(team: TeamType): Promise<void> {
       const teammateStore = useTeammateStore();
-      this.setTeamSelected(team);
+
       // fetch team teammates
       await teammateStore.setListOfTeammatesWithinTeam(team.id);
+
+      // if same team is selected, no need to set the team info again, and fetch the logo again
+      if (this.getTeamSelected.id === team.id) return;
+
+      this.setTeamSelected(team);
+      this.getTeamLogo(team.id);
     },
 
     /**
@@ -135,6 +148,34 @@ export const useTeamStore = defineStore("teamStore", {
       return this.getTeamDeleted;
     },
 
+    /**
+     * Get the team logo of a team given its id
+     * @param teamId id of the team
+     */
+    async getTeamLogo(teamId: number): Promise<void> {
+      const teamLogo: TeamLogoType = await teamLogoService.getTeamLogo(teamId);
+      this.teamSelectedLogo = teamLogo;
+    },
+
+    /**
+     * Fetch the team logo of a team
+     * @param teamId id of the team
+     * @returns TeamLogoType
+     * @throws Error if the team logo is not found
+     */
+    async createOrUpdateTeamLogo(logo: File): Promise<void> {
+      const teamId = this.getTeamSelected.id;
+      const savedTeamLogo: TeamLogoType = await teamLogoService.createOrUpdateTeamLogo(
+        teamId,
+        logo,
+      );
+
+      if (savedTeamLogo.teamLogoBlob === null) return;
+
+      this.teamSelectedLogo = savedTeamLogo;
+    },
+
+    // ----------------------------------------------------------------------------------------------
     // DEPRECIATED WITH BASTI CHANGE ? ---------------------------------------------------------------
 
     setCaptainIdToBeAssign(captainId: number | null) {

--- a/yaki_admin/src/ui/components/PageContentHeader.vue
+++ b/yaki_admin/src/ui/components/PageContentHeader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import buttonTextIcon from "@/ui/components/buttons/ButtonTextIcon.vue";
 import buttonIcon from "@/ui/components/buttons/ButtonIcon.vue";
-import teamImage from "@/assets/images/teamDefaultImg2.svg";
 import addIcon from "@/assets/icons_svg/AddPlus.svg";
 import dotIcon from "@/assets/icons_svg/3dots.svg";
 
@@ -12,6 +11,7 @@ import { useTeamStore } from "@/stores/teamStore";
 import { useModalToggleWithOutsideClickHandler } from "@/composable/useModalToggleWithOutsideClickHandler";
 import { computed } from "vue";
 import { INVITEDROLE } from "@/constants/pathParam.enum";
+import { setTeamLogoUrl } from "@/utils/images.utils";
 
 const teamStore = useTeamStore();
 
@@ -59,7 +59,7 @@ const { isModalVisible, switchModalVisibility } = useModalToggleWithOutsideClick
       <section>
         <figure v-if="isTeamManagement">
           <img
-            :src="teamImage"
+            :src="setTeamLogoUrl(teamStore.getTeamSelectedLogo.teamLogoBlob)"
             alt=""
           />
         </figure>

--- a/yaki_admin/src/ui/components/UserList.vue
+++ b/yaki_admin/src/ui/components/UserList.vue
@@ -6,7 +6,7 @@ import { useTeamStore } from "@/stores/teamStore";
 
 const teamStore = useTeamStore();
 
-const props = defineProps({
+defineProps({
   userList: {
     type: Object as PropType<UserWithIdType[]>,
     required: true,

--- a/yaki_admin/src/ui/components/buttons/ButtonIcon.vue
+++ b/yaki_admin/src/ui/components/buttons/ButtonIcon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
 
-const props = defineProps({
+defineProps({
   icon: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/buttons/ButtonTextIcon.vue
+++ b/yaki_admin/src/ui/components/buttons/ButtonTextIcon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
 
-const props = defineProps({
+defineProps({
   text: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/buttons/ButtonTextSized.vue
+++ b/yaki_admin/src/ui/components/buttons/ButtonTextSized.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
 
-const props = defineProps({
+defineProps({
   text: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/inputs/InputPassword.vue
+++ b/yaki_admin/src/ui/components/inputs/InputPassword.vue
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import eyesClosedIcon from "@/assets/icons_svg/Eye.svg";
 import eyesOpenedIcon from "@/assets/icons_svg/Eye.svg";
 
-const props = defineProps({
+defineProps({
   labelText: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/inputs/InputTextArea.vue
+++ b/yaki_admin/src/ui/components/inputs/InputTextArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = defineProps({
+defineProps({
   labelText: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
+++ b/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
@@ -107,6 +107,7 @@ const props = defineProps({
   gap: 5px;
 }
 .no-teams {
+  font-family: "Rubik";
   padding-inline-start: 16px;
   padding-block: 8px;
   color: rgb(238, 237, 237);

--- a/yaki_admin/src/utils/images.utils.ts
+++ b/yaki_admin/src/utils/images.utils.ts
@@ -4,6 +4,7 @@ import avatarH from "@/assets/images/avatarH.svg";
 import avatarF from "@/assets/images/avatarF.svg";
 import avatarN from "@/assets/images/avatarN.svg";
 import userAvatar from "@/assets/images/avatarLetters.png";
+import teamImage from "@/assets/images/teamDefaultImg2.svg";
 
 export const setUserAvatarUrl = (user: UserWithIdType) => {
   switch (user.avatarReference) {
@@ -17,5 +18,13 @@ export const setUserAvatarUrl = (user: UserWithIdType) => {
       return avatarN;
     default:
       return userAvatar;
+  }
+};
+
+export const setTeamLogoUrl = (teamLogo: Uint8Array | null) => {
+  if (teamLogo) {
+    return `data:image/jpeg;base64,${teamLogo}`;
+  } else {
+    return teamImage;
   }
 };

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
@@ -22,10 +22,9 @@ public class TeamLogoServiceImpl implements TeamLogoService {
 
         if (OptionalTeamLogoModel.isPresent()) {
             TeamLogoModel teamLogoModel = OptionalTeamLogoModel.get();
-
             return teamLogoModel.toEntity();
         } else {
-            throw new EntityNotFoundException("Team logo not found");
+            return new TeamLogoEntity(0, null);
         }
     }
 


### PR DESCRIPTION
# Description
What are changes related to ?

set teamLogoService for GET and PUT to retrice or create / update the selecte team logo
Display the logo in the create or edit team modal, and display it in the selected team content header.
Add warning and prevent user to upload a file too heavy

# Linked Issues
What are the issues fixed by this pull request ?
#1204

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="791" alt="Capture d’écran 2024-01-16 à 14 47 55" src="https://github.com/XPEHO/YAKI/assets/95299697/2229481a-0787-414f-87e4-855929c13f82">
<img width="708" alt="Capture d’écran 2024-01-16 à 14 48 02" src="https://github.com/XPEHO/YAKI/assets/95299697/61daa4c8-10b7-4848-9d62-891d52de19b3">
<img width="449" alt="Capture d’écran 2024-01-16 à 14 48 10" src="https://github.com/XPEHO/YAKI/assets/95299697/5eeac5c3-d928-499e-bc55-90be24d4ef49">

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
