### PR TITLE
fix(logo_deletion): review modal deletion press behavior

### DIFF
--- a/yaki_admin/src/composable/userFilePicker.ts
+++ b/yaki_admin/src/composable/userFilePicker.ts
@@ -1,6 +1,6 @@
 import { MODALMODE } from "@/constants/modalMode.enum";
 import { setTeamLogoUrl } from "@/utils/images.utils";
-import teamImage from "@/assets/images/teamDefaultImg2.svg";
+import defaultTeamImage from "@/assets/images/teamDefaultImg2.svg";
 import { ref } from "vue";
 import { useTeamStore } from "@/stores/teamStore";
 
@@ -10,29 +10,33 @@ import { useTeamStore } from "@/stores/teamStore";
  * This function is responsible for handling the user's file input.
  *
  * @returns {Object} An object containing the following properties:
- * - logoSrc: ref holding the source URL of image. Initially set to a default image.
- * - isLogoToHeavy: ref indicating whether the selected file is too large (> 500KB), use in component to display a warning message.
- * - selectedFile: ref holding the selected File object.
- * - openFilePicker: A function that triggers the file input click event to open the file picker dialog.
- * - handleFileSelected: A function that handles the file input change event.
- * - setTeamLogo: A function that sets the team logo URL based on the current team selected logo.
+ * - logoDisplayed: ref holding the source URL of the logo image used to be displayed in a img src. Initially set to a default image.
+ * - isFileSizeTooBig: ref indicating whether the selected file is too large (> 500KB). Used in component to display a warning message.
+ * - inputFileElement: ref holding the input file HTML element (vue3 alternative to querySelector).
+ * - isLogoToBeDeleted: ref indicating whether option to delete the logo is selected.
+ * - triggerFilePickerAndResetSizeFlag: Function : Triggers the file input click to open the file picker dialog and resets the file size flag.
+ * - handleSelectedFileAndValidation: Function : Handles the file input change event, validates the selected file, and updates the logoDisplayed ref to preview the selected image
+ * - setTeamLogoToDisplay: Function : Sets the logoDisplayed ref based on if the modal is displayed and mode.
+ * - setDefaultLogo: Function : Sets the logoDisplayed ref to the default team image.
+ * - createOrDeleteLogo: Function : Deletes the team logo or creates/updates it based on the isLogoToBeDeleted and fileSelected refs.
  */
 export function userFilePicker() {
   const teamStore = useTeamStore();
 
-  // file handling
+  const inputFileElement = ref<HTMLElement | null>(null);
+  const fileSelected = ref<File | null>(null);
+  const isFileSizeTooBig = ref<boolean>(false);
+  const fileSizeLimit: number = 500000; // 500KB
 
-  const selectedFile = ref<File | null>(null);
-  const logoSrc = ref(teamImage);
-  const isLogoToHeavy = ref(false);
+  const logoDisplayed = ref(defaultTeamImage);
+  const isLogoToBeDeleted = ref<boolean>(false);
 
-  const setTeamLogo = (newIsShow: boolean, newMode: MODALMODE) => {
-    if (!newIsShow || (newMode !== MODALMODE.teamEdit && newMode !== MODALMODE.teamCreate)) {
-      return;
-    }
-    const currentLogo = teamStore.getTeamSelectedLogo;
-
-    logoSrc.value = setTeamLogoUrl(currentLogo.teamLogoBlob);
+  /**
+   * Trigger the file input click event to open the file picker dialog.
+   */
+  const triggerFilePickerAndResetSizeFlag = () => {
+    inputFileElement.value!.click();
+    if (isFileSizeTooBig.value) isFileSizeTooBig.value = false;
   };
 
   /**
@@ -46,39 +50,78 @@ export function userFilePicker() {
    * @param event - The event object associated with the file input change event.
    * @returns void
    */
-  const handleFileSelected = async (event: Event) => {
+  const handleSelectedFileAndValidation = async (event: Event) => {
     const target = event.target as HTMLInputElement;
 
-    if (target.files) {
-      const file = target.files[0];
-      selectedFile.value = file;
+    // if no file selected, return
+    if (!target.files) return;
 
-      if (file.size > 500000) {
-        isLogoToHeavy.value = true;
-        return;
-      }
+    const file = target.files[0];
+    fileSelected.value = file;
 
-      // Object async read files (raw data or buffer)
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        // triggered when the read operation is finished, and apply the reader.result to the avatarSrc
-        logoSrc.value = reader.result as string;
-      };
-      // read the blob or file content as a base64 encoded string
-      reader.readAsDataURL(selectedFile.value);
+    if (file.size > fileSizeLimit) {
+      isFileSizeTooBig.value = true;
+      return;
+    }
+
+    // reset logo deletion effect on newselected file
+    if (isLogoToBeDeleted.value) isLogoToBeDeleted.value = false;
+
+    // Object async read files (raw data or buffer)
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      // triggered when the read operation is finished, and apply the reader.result to the avatarSrc
+      logoDisplayed.value = reader.result as string;
+    };
+    // read the blob or file content as a base64 encoded string
+    reader.readAsDataURL(fileSelected.value);
+  };
+
+  /**
+   * Triggered in ModalCreateEdit in watch (modalStore.isShow or modalStore.mode)
+   * if the modal is show and the mode is teamEdit or teamCreate, retrive the current team logo.
+   * And set it to the logoSrc, ref used to display the logo image.
+   * @param newIsShow modalStore is show value
+   * @param newMode  modalStore mode value
+   * @returns
+   */
+  const setTeamLogoToDisplay = (newIsShow: boolean, newMode: MODALMODE) => {
+    if (!newIsShow || (newMode !== MODALMODE.teamEdit && newMode !== MODALMODE.teamCreate)) {
+      return;
+    }
+    const currentLogo = teamStore.getTeamSelectedLogo;
+
+    logoDisplayed.value = setTeamLogoUrl(currentLogo.teamLogoBlob);
+  };
+
+  /**
+   * Create or delete the team logo.
+   * Based on the isLogoToBeDeleted and fileSelected refs.
+   */
+  const createOrDeleteLogo = async () => {
+    // if logo is to be deleted, delete it
+    if (isLogoToBeDeleted.value) {
+      await teamStore.deleteTeamLogo();
+
+      // set back default logo
+      logoDisplayed.value = defaultTeamImage;
+    }
+
+    // if logo is not to be deleted and a file is selected, create or update the logo
+    if (!isLogoToBeDeleted.value && fileSelected.value) {
+      await teamStore.createOrUpdateTeamLogo(fileSelected.value);
+      fileSelected.value = null;
     }
   };
 
-  const setDefaultLogo = () => {
-    logoSrc.value = teamImage;
-  };
-
   return {
-    logoSrc,
-    isLogoToHeavy,
-    selectedFile,
-    handleFileSelected,
-    setTeamLogo,
-    setDefaultLogo,
+    logoDisplayed,
+    isFileSizeTooBig,
+    inputFileElement,
+    isLogoToBeDeleted,
+    triggerFilePickerAndResetSizeFlag,
+    handleSelectedFileAndValidation,
+    setTeamLogoToDisplay,
+    createOrDeleteLogo,
   };
 }

--- a/yaki_admin/src/ui/components/buttons/ButtonPrimary.vue
+++ b/yaki_admin/src/ui/components/buttons/ButtonPrimary.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
 
-const props = defineProps({
+defineProps({
   text: {
     type: String,
     required: true,

--- a/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
@@ -6,58 +6,79 @@ import ButtonTextSized from "@/ui/components/buttons/ButtonTextSized.vue";
 
 import pencilIcon from "@/assets/icons_svg/Edit.svg";
 import deleteIcon from "@/assets/icons_svg/CrossClose.svg";
+import defaultTeamImage from "@/assets/images/teamDefaultImg2.svg";
 
-import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
-import { useModalStore } from "@/stores/modalStore";
-import { useTeamStore } from "@/stores/teamStore";
 import { ref, watch } from "vue";
 
+import { BUTTONCOLORS } from "@/constants/componentsSettings.enum";
 import { MODALMODE } from "@/constants/modalMode.enum";
-
+import { useModalStore } from "@/stores/modalStore";
 import { userFilePicker } from "@/composable/userFilePicker";
 
 const modalStore = useModalStore();
-const teamStore = useTeamStore();
-const isMissingTeamNameError = ref(false);
-const fileInput = ref<HTMLElement | null>(null);
+const isMissingTeamNameError = ref<boolean>(false);
+const onOpenDisplayedLogo = ref("");
 
-const { logoSrc, isLogoToHeavy, selectedFile, handleFileSelected, setTeamLogo, setDefaultLogo } =
-  userFilePicker();
+const {
+  logoDisplayed,
+  isFileSizeTooBig,
+  inputFileElement,
+  isLogoToBeDeleted,
+  triggerFilePickerAndResetSizeFlag,
+  handleSelectedFileAndValidation,
+  setTeamLogoToDisplay,
+  createOrDeleteLogo,
+} = userFilePicker();
 
 const modalText = ref({
   title: "",
   text: "",
 });
 
-const teamEdition = {
-  title: "Team edition",
-  text: "You can edit your team name, description and logo",
-};
-
-const teamCreation = {
-  title: "Team creation",
-  text: "The team name must be provided. You can also add a description and a logo",
-};
-
+/**
+ * Depending on the modal mode, change the modal text
+ * @param newIsShow modalStore.getIsShow
+ * @param newMode modalStore.getMode
+ */
 const setCardText = (newIsShow: boolean, newMode: MODALMODE) => {
   if (newIsShow && newMode === MODALMODE.teamEdit) {
-    modalText.value = teamEdition;
+    modalText.value = {
+      title: "Team edition",
+      text: "You can edit your team name, description and logo",
+    };
   } else if (newIsShow && newMode === MODALMODE.teamCreate) {
-    modalText.value = teamCreation;
+    modalText.value = {
+      title: "Team creation",
+      text: "The team name must be provided. You can also add a description and a logo",
+    };
   }
 };
 
+// when the modal is shown and display this component.
 watch(
   [() => modalStore.getMode, () => modalStore.getIsShow],
   ([newMode, newIsShow]) => {
-    setTeamLogo(newIsShow, newMode);
+    setTeamLogoToDisplay(newIsShow, newMode);
     setCardText(newIsShow, newMode);
+
+    onOpenDisplayedLogo.value = logoDisplayed.value;
   },
   { immediate: true },
 );
 
-const emit = defineEmits(["onAccept", "onCancel"]);
+/**
+ * Reset the state of :
+ * * isMissingTeamNameError (error when user try to submit an empty team name)
+ * * isFileSizeTooBig (error when user try to submit a logo that is too heavy)
+ * * isLogoToBeDeleted (flag to delete the logo)
+ */
+const resetRef = () => {
+  if (isMissingTeamNameError.value) isMissingTeamNameError.value = false;
+  if (isFileSizeTooBig.value) isFileSizeTooBig.value = false;
+  if (isLogoToBeDeleted.value) isLogoToBeDeleted.value = false;
+};
 
+const emit = defineEmits(["onAccept", "onCancel"]);
 /**
  * Check if the inputvalue saved in the modalStore is empty.
  * if it is, set the error to true to display the error message. Preventing the accept action to be executed.
@@ -68,13 +89,45 @@ const onAcceptPress = async () => {
     isMissingTeamNameError.value = true;
     return;
   }
-
-  if (selectedFile.value) {
-    await teamStore.createOrUpdateTeamLogo(selectedFile.value);
-    selectedFile.value = null;
-  }
+  await createOrDeleteLogo();
 
   emit("onAccept");
+  resetRef();
+};
+
+/**
+ * Execute the cancel action (using emit to send the event to the ModalFrame parent component)
+ */
+const onCancelPress = () => {
+  emit("onCancel");
+  resetRef();
+};
+
+/**
+ * On delete logo button press.
+ * * On modal open :
+ * * * Initial logo is an image, set the **delete flag** to true
+ * * * Initial logo is the *default logo*, if a file was selected, set the *default logo* back
+ * * * Initial logo is an image and a new image was selected, set the preview image back
+ * * Reset the **delete flag** by pressing the button again.
+ */
+const deleteTeamLogo = () => {
+  if (isLogoToBeDeleted.value) {
+    isLogoToBeDeleted.value = false;
+    return;
+  }
+
+  if (onOpenDisplayedLogo.value === defaultTeamImage) {
+    // set back default logo
+    logoDisplayed.value = defaultTeamImage;
+  } else {
+    if (onOpenDisplayedLogo.value !== logoDisplayed.value) {
+      // set back preview image
+      logoDisplayed.value = onOpenDisplayedLogo.value;
+    } else {
+      isLogoToBeDeleted.value = true;
+    }
+  }
 };
 
 /**
@@ -89,46 +142,29 @@ const setTeamName = (value: string) => {
   modalStore.setTeamNameInputValue(value);
 };
 
+/**
+ * Register the input value in the modalStore.
+ * @param value being emitted by the InputTextArea component
+ */
 const setTeamDescription = (value: string) => {
   modalStore.setTeamDescriptionInputValue(value);
-};
-
-/**
- * Execute the cancel action (using emit to send the event to the ModalFrame parent component)
- */
-const onCancelPress = () => {
-  if (isMissingTeamNameError.value) isMissingTeamNameError.value = false;
-  if (isLogoToHeavy.value) isLogoToHeavy.value = false;
-  emit("onCancel");
-};
-
-/**
- * Trigger the file input click event to open the file picker dialog.
- */
-const openFilePicker = () => {
-  fileInput.value!.click();
-
-  if (isLogoToHeavy.value) isLogoToHeavy.value = false;
-};
-
-const deleteTeamLogo = () => {
-  teamStore.deleteTeamLogo();
-  setDefaultLogo();
 };
 </script>
 
 <template>
   <section class="container__popup">
     <h1 class="container__title-text container__style">{{ modalText.title }}</h1>
-    <p :class="['container__text', 'container__style', isLogoToHeavy ? 'is_logo_too_heavy' : '']">
+    <p
+      :class="['container__text', 'container__style', isFileSizeTooBig ? 'is_logo_too_heavy' : '']"
+    >
       {{ modalText.text }}
     </p>
 
     <section class="popup__content">
       <section class="popup__avatar-section">
-        <figure>
+        <figure :class="[isLogoToBeDeleted ? 'logo_to_be_deleted logo_to_delete_filter' : '']">
           <img
-            :src="logoSrc"
+            :src="logoDisplayed"
             alt="avatar"
           />
         </figure>
@@ -140,14 +176,14 @@ const deleteTeamLogo = () => {
           />
           <button-icon
             :icon="pencilIcon"
-            @click="openFilePicker"
+            @click="triggerFilePickerAndResetSizeFlag"
           />
           <input
             class="display_none"
             type="file"
             name="file"
-            ref="fileInput"
-            @change="handleFileSelected"
+            ref="inputFileElement"
+            @change="handleSelectedFileAndValidation"
           />
         </aside>
       </section>
@@ -190,7 +226,7 @@ const deleteTeamLogo = () => {
 <style scoped lang="scss">
 .is_logo_too_heavy:after {
   font-family: $font-sf-compact;
-  content: "Your logo is too heavy. Please select a logo under 500kb.";
+  content: "Your logo size is too big. Please select a logo under 500kb.";
   position: absolute;
   top: 26.5%;
   left: 50px;
@@ -201,5 +237,27 @@ const deleteTeamLogo = () => {
 
 .display_none {
   display: none;
+}
+
+.logo_to_be_deleted {
+  position: relative;
+
+  filter: grayscale(100%) brightness(0.7);
+
+  &:after {
+    content: "✕";
+    position: absolute;
+
+    font-size: 7rem;
+    color: white;
+
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    z-index: 1;
+
+    filter: none;
+  }
 }
 </style>


### PR DESCRIPTION
# Description
What are changes related to ?

create visual effect on team modal image when pressing the deletion button to indicated that the image will be deleted.
Add different behavior depending of the image present on modal opening
- If start from the default image, and add an image, go back to the default image directly, 
- same behavior starting from a custom image, will go back to the initial custom image
- Apply the deletion effect when the user want to delete the intial custom image
- Remove the deletion trigger when pressing again the deletion button.

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="491" alt="Capture d’écran 2024-01-17 à 08 08 42" src="https://github.com/XPEHO/YAKI/assets/95299697/1ad6180f-0de5-49cd-9068-d235de52f865">


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
