### PR TITLE
fix(admin_front): fix team deletion, fix image aspect ratio, fix new team default image

### DIFF
--- a/yaki_admin/package-lock.json
+++ b/yaki_admin/package-lock.json
@@ -1498,7 +1498,7 @@
     "node_modules/@yaki_ui/yaki_ui_web_components": {
       "version": "1.0.0",
       "resolved": "https://gitpkg.now.sh/XPEHO/yaki_ui/web?feat/web_admin_ui",
-      "integrity": "sha512-XswVSMQIDh1SsWRNXFXNXhvN74QRwfdNfof1uFF+dzdUhwgKKXsOGItAfQEDSbmAUzf9K1YxZKDVknnR+9vYaA==",
+      "integrity": "sha512-CypqymGyBcEwyb8D78tXKSKxGaIxcOiyh3/HSxMF1X5MX96OndfW4ufKYotxxO6awbP05vWmZdo6PZRjkN5fUQ==",
       "license": "ISC"
     },
     "node_modules/abbrev": {

--- a/yaki_admin/src/features/invitation/components/InvitationViewHeader.vue
+++ b/yaki_admin/src/features/invitation/components/InvitationViewHeader.vue
@@ -60,17 +60,6 @@ defineProps({
   padding-block: 44px 24px;
   padding-inline: 40px;
 
-  figure {
-    background-color: black;
-    width: 48px;
-    height: 48px;
-    border-radius: 16px;
-    img {
-      width: 100%;
-      object-fit: contain;
-    }
-  }
-
   > div {
     display: flex;
     align-items: flex-start;

--- a/yaki_admin/src/stores/modalStore.ts
+++ b/yaki_admin/src/stores/modalStore.ts
@@ -74,6 +74,11 @@ export const useModalStore = defineStore("userModalStore", {
           this.setTeamDescriptionInputValue(teamDescription);
         }
       }
+
+      if (mode === MODALMODE.teamCreate) {
+        teamStore.resetTeamStoreSelectedLogo();
+      }
+
       if (mode === MODALMODE.teamCreate || mode === MODALMODE.teamDelete) {
         this.setTeamNameInputValue("");
         this.setTeamDescriptionInputValue("");

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -177,6 +177,13 @@ export const useTeamStore = defineStore("teamStore", {
 
     async deleteTeamLogo(): Promise<void> {
       teamLogoService.deleteTeamLogo(this.getTeamSelected.id);
+      this.resetTeamStoreSelectedLogo();
+    },
+
+    /**
+     * Reset the teamSelectedLogo to its initial value
+     */
+    resetTeamStoreSelectedLogo(): void {
       this.teamSelectedLogo = { teamId: 0, teamLogoBlob: null };
     },
 

--- a/yaki_admin/src/ui/components/PageContentHeader.vue
+++ b/yaki_admin/src/ui/components/PageContentHeader.vue
@@ -57,7 +57,10 @@ const { isModalVisible, switchModalVisibility } = useModalToggleWithOutsideClick
   <section class="header__container">
     <div>
       <section>
-        <figure v-if="isTeamManagement">
+        <figure
+          class="header_figure"
+          v-if="isTeamManagement"
+        >
           <img
             :src="setTeamLogoUrl(teamStore.getTeamSelectedLogo.teamLogoBlob)"
             alt=""
@@ -103,17 +106,6 @@ const { isModalVisible, switchModalVisibility } = useModalToggleWithOutsideClick
   padding-block: 44px 24px;
   padding-inline: 40px;
 
-  figure {
-    width: 48px;
-    height: 48px;
-    border-radius: 16px;
-    img {
-      width: 100%;
-      object-fit: contain;
-      border-radius: 16px;
-    }
-  }
-
   > div {
     display: flex;
     align-items: center;
@@ -126,6 +118,19 @@ const { isModalVisible, switchModalVisibility } = useModalToggleWithOutsideClick
       gap: 8px;
     }
   }
+
+  .header_figure {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 16px;
+    }
+  }
+
   .header__buttons-modal_container {
     display: flex;
     align-items: center;

--- a/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
@@ -153,10 +153,8 @@ const setTeamDescription = (value: string) => {
 
 <template>
   <section class="container__popup">
-    <h1 class="container__title-text container__style">{{ modalText.title }}</h1>
-    <p
-      :class="['container__text', 'container__style', isFileSizeTooBig ? 'is_logo_too_heavy' : '']"
-    >
+    <h1 class="container__title-text">{{ modalText.title }}</h1>
+    <p :class="['container__text', isFileSizeTooBig ? 'is_logo_too_heavy' : '']">
       {{ modalText.text }}
     </p>
 
@@ -169,7 +167,7 @@ const setTeamDescription = (value: string) => {
           />
         </figure>
 
-        <aside class="container__buttons">
+        <aside class="container__buttons_aside">
           <button-icon
             :icon="deleteIcon"
             @click="deleteTeamLogo"
@@ -188,37 +186,35 @@ const setTeamDescription = (value: string) => {
         </aside>
       </section>
 
-      <section class="popup__content">
-        <form class="popup__input-container">
-          <input-text
-            label-text="Team name"
-            :inputValue="modalStore.getTeamNameInputValue"
-            @emittedInput="setTeamName"
-            :isError="isMissingTeamNameError"
-          />
+      <form class="popup__input-container">
+        <input-text
+          label-text="Team name"
+          :inputValue="modalStore.getTeamNameInputValue"
+          @emittedInput="setTeamName"
+          :isError="isMissingTeamNameError"
+        />
 
-          <input-text-area
-            label-text="'Team description'"
-            :inputValue="modalStore.getTeamDescriptionInputValue"
-            @emittedInput="setTeamDescription"
-          />
+        <input-text-area
+          label-text="'Team description'"
+          :inputValue="modalStore.getTeamDescriptionInputValue"
+          @emittedInput="setTeamDescription"
+        />
 
-          <section class="container__buttons--popup">
-            <button-text-sized
-              text="Cancel"
-              :color="BUTTONCOLORS.secondary"
-              @click.prevent="onCancelPress"
-              type="button"
-            />
-            <button-text-sized
-              text="Modify"
-              :color="BUTTONCOLORS.primary"
-              @click.prevent="onAcceptPress"
-              type="submit"
-            />
-          </section>
-        </form>
-      </section>
+        <section class="container__buttons_form">
+          <button-text-sized
+            text="Cancel"
+            :color="BUTTONCOLORS.secondary"
+            @click.prevent="onCancelPress"
+            type="button"
+          />
+          <button-text-sized
+            text="Modify"
+            :color="BUTTONCOLORS.primary"
+            @click.prevent="onAcceptPress"
+            type="submit"
+          />
+        </section>
+      </form>
     </section>
   </section>
 </template>

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImpl.java
@@ -4,7 +4,6 @@ import com.xpeho.yaki_admin_backend.data.models.TeamLogoModel;
 import com.xpeho.yaki_admin_backend.data.sources.TeamLogoRepository;
 import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
 import com.xpeho.yaki_admin_backend.domain.services.TeamLogoService;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -53,15 +52,16 @@ public class TeamLogoServiceImpl implements TeamLogoService {
         }
     }
 
-    public TeamLogoEntity deleteByTeamId(int teamId) {
+    public Optional<TeamLogoEntity> deleteByTeamId(int teamId) {
         Optional<TeamLogoModel> OptinalTeamLogoModel = teamLogoRepository.findOptionalByTeamLogoTeamId(teamId);
 
         if (OptinalTeamLogoModel.isPresent()) {
             TeamLogoModel teamLogoModelToDelete = OptinalTeamLogoModel.get();
             teamLogoRepository.delete(teamLogoModelToDelete);
-            return teamLogoModelToDelete.toEntity();
+            return Optional.of(teamLogoModelToDelete.toEntity());
         } else {
-            throw new EntityNotFoundException("Team logo not found");
+            return Optional.empty();
         }
+        // If there's no TeamLogo to delete, do nothing and return
     }
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/TeamServiceImpl.java
@@ -143,7 +143,7 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public TeamEntity disabled(int teamId) {
         Optional<TeamModel> teamModelOpt = teamJpaRepository.findById(teamId);
-        // delete logo rown when disable team
+            // Delete logo row when disable team. If there's no logo to delete, this will do nothing.
         teamLogoService.deleteByTeamId(teamId);
 
         if (teamModelOpt.isEmpty()) {

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/TeamLogoService.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/domain/services/TeamLogoService.java
@@ -2,11 +2,13 @@ package com.xpeho.yaki_admin_backend.domain.services;
 
 import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
 
+import java.util.Optional;
+
 public interface TeamLogoService {
     TeamLogoEntity getTeamLogoByTeamId(int id);
     TeamLogoEntity save(TeamLogoEntity teamLogoEntity);
 
     TeamLogoEntity createOrUpdateByTeamId(int id, byte[] teamLogoBlob);
 
-    TeamLogoEntity deleteByTeamId(int id);
+    Optional<TeamLogoEntity> deleteByTeamId(int id);
 }

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoController.java
@@ -4,9 +4,11 @@ import com.xpeho.yaki_admin_backend.domain.entities.TeamLogoEntity;
 import com.xpeho.yaki_admin_backend.domain.services.TeamLogoService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import java.util.Optional;
 
 @CrossOrigin
 @RestController
@@ -37,8 +39,13 @@ public class TeamLogoController {
     }
 
     @DeleteMapping()
-    public TeamLogoEntity deleteByTeamId(@PathVariable int id) {
-        return teamLogoService.deleteByTeamId(id);
+    public ResponseEntity<?> deleteByTeamId(@PathVariable int id) {
+        Optional<TeamLogoEntity> teamLogoEntity = teamLogoService.deleteByTeamId(id);
+        if (teamLogoEntity.isPresent()) {
+            return new ResponseEntity<>(teamLogoEntity.get(), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
     }
 
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImplTest.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/data/services/TeamLogoServiceImplTest.java
@@ -17,9 +17,8 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -88,10 +87,10 @@ public class TeamLogoServiceImplTest {
         TeamLogoModel teamLogoModelToDelete = new TeamLogoModel(1, logoBlob);
         given(teamLogoRepository.findOptionalByTeamLogoTeamId(1)).willReturn(Optional.of(teamLogoModel1));
         // when
-        TeamLogoEntity teamLogoEntity = teamLogoService.deleteByTeamId(1);
+        teamLogoService.deleteByTeamId(1);
         // then
-        assertThat(teamLogoEntity.teamId(), is(equalTo(teamLogoEntityToDelete.teamId())));
-        assertTrue(Arrays.equals(teamLogoEntity.teamLogoBlob(), teamLogoEntityToDelete.teamLogoBlob()));
+        Optional<TeamLogoModel> teamLogoEntity = teamLogoRepository.findOptionalByTeamLogoTeamId(1);
+        assertThat(teamLogoEntity.isPresent(), is(true));
     }
 
 }

--- a/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoControllerTests.java
+++ b/yaki_admin_backend/src/test/java/com/xpeho/yaki_admin_backend/presentation/controllers/TeamLogoControllerTests.java
@@ -20,6 +20,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -87,7 +89,8 @@ public class TeamLogoControllerTests {
     @Test
     public void shouldDeleteTeamLogoByTeamId() throws Exception {
 
-        given(teamLogoService.deleteByTeamId(1)).willReturn(teamLogoEntity);
+        Optional<TeamLogoEntity> teamLogoEntityOptional = Optional.of(teamLogoEntity);
+        given(teamLogoService.deleteByTeamId(1)).willReturn(teamLogoEntityOptional);
 
         MockHttpServletResponse response = mvc.perform(
                         MockMvcRequestBuilders.delete("/teams/1/logo")


### PR DESCRIPTION
# Description
What are changes related to ?

fix : 
* fix issue with team deletion
* fix aspect ratio in team page content header
* fix css for the create / edit team modal (changed in yakiUI)
* reset teamlogo data from teamStore to the default values when creating a new team, preventing to have preview


# Linked Issues
What are the issues fixed by this pull request ?
#1225

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="892" alt="Capture d’écran 2024-01-17 à 12 51 51" src="https://github.com/XPEHO/YAKI/assets/95299697/b7a17101-caf8-43b3-ab67-ed60c98aa85d">

<img width="338" alt="Capture d’écran 2024-01-17 à 12 59 52" src="https://github.com/XPEHO/YAKI/assets/95299697/988bc21a-470a-463c-8216-c8549774f0b4">

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
