### PR TITLE
fix(removed-search-bar): removed search icon

### DIFF
--- a/yaki_mobile/lib/presentation/features/teams_declarations_summary/teams_declarations_summary.dart
+++ b/yaki_mobile/lib/presentation/features/teams_declarations_summary/teams_declarations_summary.dart
@@ -31,24 +31,6 @@ class TeamsDeclarationSummary extends ConsumerWidget {
           ),
           IconButton(
             icon: const NavIconCircleAvatar(
-              imageSrc: 'assets/images/Search.svg',
-            ),
-            onPressed: () {
-              showModalBottomSheet(
-                context: context,
-                builder: (BuildContext context) {
-                  return const SizedBox(
-                    height: 200,
-                    child: Center(
-                      child: Text('Coming soon'),
-                    ),
-                  );
-                },
-              );
-            },
-          ),
-          IconButton(
-            icon: const NavIconCircleAvatar(
               imageSrc: 'assets/images/Account.svg',
             ),
             onPressed: () {


### PR DESCRIPTION
# Description
What are changes related to ?  the search icon from the teams_summary_declaration is not needed, therefore it is remove

# Linked Issues
What are the issues fixed by this pull request ? #1209 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

<img width="955" alt="image" src="https://github.com/XPEHO/YAKI/assets/96787811/3f871353-b205-4d6a-9afc-afee29c41318">


# Tests
How has it been tested ?

- [X] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
