### PR TITLE
fix(fr_translation): fix incorrect error message translation in absence date page

### DIFF
--- a/yaki_mobile/assets/translations/fr.json
+++ b/yaki_mobile/assets/translations/fr.json
@@ -140,5 +140,5 @@
   "absenceDatePickerInitialLabel": "Choisir une date",
   "absenceStart": "Début",
   "absenceEnd": "Fin",
-  "absenceError": "* Veuillez renseigner une date de début et de fin, \n Votre date de fin doit être antérieur ou identique à votre date de début"
+  "absenceError": "* Veuillez renseigner une date de début et de fin, \n Votre date de début doit être antérieur ou identique à votre date de fin"
 }


### PR DESCRIPTION
# Description
What are changes related to ?

incorrect error message translation to correctly indicate that the absence start date must be before the absence end date.
The message was indicating the opposite

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
