### PR TITLE
fix(get-total-pages): add the possibility to have the total page for …

### DIFF
--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
@@ -117,7 +117,12 @@ public class UserServiceImpl implements UserService {
         // The result is a Pageable object that we can pass to the findAll() method to retrieve a page of users, sorted by last name.
 
         Pageable sortedByName = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by("lastName"));
+
+        // Use the UserRepository to find all users, sorted by last name, and return them as a Page of UserModels.
+        // The findAll method takes the Pageable object as a parameter, which includes the page number, page size, and sorting details.
         Page<UserModel> userPage = userJpaRepository.findAll(sortedByName);
+
+        // Get the total number of pages in the result set. This is calculated based on the total number of items and the page size.
         int totalPages = userPage.getTotalPages();
 
         return userPage.map(user -> new UserEntityWithID(

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/data/services/UserServiceImpl.java
@@ -118,7 +118,8 @@ public class UserServiceImpl implements UserService {
 
         Pageable sortedByName = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by("lastName"));
         Page<UserModel> userPage = userJpaRepository.findAll(sortedByName);
-        
+        int totalPages = userPage.getTotalPages();
+
         return userPage.map(user -> new UserEntityWithID(
                 user.getUserId(),
                 null,

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
@@ -39,17 +39,29 @@ public class UserController {
         return userService.findUserByIdRange(idStart, idEnd);
     }
 
+    // Define a GET mapping for the root path. This method will be invoked when a GET request is made to the root path.
     @GetMapping()
     public ResponseEntity<Map<String, Object>> findAllUsers(
+            // Request parameters for the page number and size. If not provided, they default to 0 and 10 respectively.
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
+
+        // Create a Pageable object with the provided page number and size. This is used to add pagination information to the database query.
         Pageable pageable = PageRequest.of(page, size);
+
+        // Call the userService to get a Page of UserEntityWithID. The Page includes the data for the requested page, as well as pagination information.
         Page<UserEntityWithID> userPage = userService.findAllUsers(pageable);
 
+        // Create a map to hold the response data.
         Map<String, Object> response = new HashMap<>();
+
+        // Add the list of users to the response map. The getContent() method is used to get the list of UserEntityWithID from the Page.
         response.put("users", userPage.getContent());
+
+        // Add the total number of pages to the response map. The getTotalPages() method is used to get the total number of pages from the Page.
         response.put("totalPages", userPage.getTotalPages());
 
+        // Return the response map as the body of a ResponseEntity. The status is set to OK to indicate that the request was successful.
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
+++ b/yaki_admin_backend/src/main/java/com/xpeho/yaki_admin_backend/presentation/controllers/UserController.java
@@ -6,11 +6,16 @@ import com.xpeho.yaki_admin_backend.domain.entities.UserEntityIn;
 import com.xpeho.yaki_admin_backend.domain.entities.UserEntityWithID;
 import com.xpeho.yaki_admin_backend.domain.services.UserService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @CrossOrigin
 @RestController
@@ -35,11 +40,17 @@ public class UserController {
     }
 
     @GetMapping()
-    public List<UserEntityWithID> findAllUsers(
+    public ResponseEntity<Map<String, Object>> findAllUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return userService.findAllUsers(pageable).getContent();
+        Page<UserEntityWithID> userPage = userService.findAllUsers(pageable);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("users", userPage.getContent());
+        response.put("totalPages", userPage.getTotalPages());
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 


### PR DESCRIPTION
…fetch all users in findAllUsers

# Description
What are changes related to ?  add the possibility to have the total page for to fetch all users in findAllUsers

`http://localhost:8080/users?page=0&size=10`

to get the total page : `    "totalPages": 2,`

# Linked Issues
What are the issues fixed by this pull request ? #1257 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="311" alt="image" src="https://github.com/XPEHO/YAKI/assets/96787811/8ff06067-0b7e-4eb2-b3c0-727fd99ea5db">


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
