### PR TITLE
fix(mobile_absence): do not display team chips along with an afternoonn absence in teams summary page

### DIFF
--- a/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_opened_iconchips.dart
+++ b/yaki_mobile/lib/presentation/features/teams_declarations_summary/view/cell_opened_iconchips.dart
@@ -55,6 +55,9 @@ class CellOpenedIconChips extends ConsumerWidget {
     final bool absentOrUndeclared =
         status == StatusEnum.undeclared || status == StatusEnum.absence;
 
+    final bool isUserIsInAfternoonTeamAndNotAbsent =
+        isUserIsInAfternoonTeam && statusAfternoon != StatusEnum.absence;
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -105,7 +108,8 @@ class CellOpenedIconChips extends ConsumerWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              if (isUserIsInAfternoonTeam) ...[
+              // do not display team chip if the user is not in the afternoon team or if he is absent
+              if (isUserIsInAfternoonTeamAndNotAbsent) ...[
                 IconChip(
                   label: teamNameAfternoon!,
                   backgroundColor: AppColors.cellChipDefault,
@@ -121,8 +125,14 @@ class CellOpenedIconChips extends ConsumerWidget {
                 ),
                 const SizedBox(
                   width: 4,
+                  height: 8,
                 ),
-                const SizedBox(height: 8),
+              ],
+              // no need to display this chip if the user neither is into the morning team (only one unavailable chip is enough for the day)
+              if (!isUserIsInAfternoonTeam && isUserIsInTeam)
+                const UnavailableIconChip(),
+
+              if (isUserIsInAfternoonTeam || absentOrUndeclared)
                 IconChip(
                   label: tr(statusAfternoon!.name),
                   backgroundColor: setStatusColor(statusAfternoon!),
@@ -134,10 +144,6 @@ class CellOpenedIconChips extends ConsumerWidget {
                     ),
                   ),
                 ),
-              ],
-              // no need to display this chip if the user neither is into the morning team (only one unavailable chip is enough for the day)
-              if (!isUserIsInAfternoonTeam && isUserIsInTeam)
-                const UnavailableIconChip(),
             ],
           ),
       ],


### PR DESCRIPTION
# Description
What are changes related to ?

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
