### PR TITLE
refactor(store): move team method from modalstore to teamstore, so for teammate and captain

### DIFF
--- a/yaki_admin/src/features/invitation/layouts/UserInvitationPageContent.vue
+++ b/yaki_admin/src/features/invitation/layouts/UserInvitationPageContent.vue
@@ -8,7 +8,6 @@ import InvitationViewHeader from "@/features/invitation/components/InvitationVie
 import UserInvitationList from "@/features/invitation/components/UserInvitationList.vue";
 
 import { useRoute } from "vue-router";
-import { useTeamStore } from "@/stores/teamStore";
 import { INVITEDROLE } from "@/constants/pathParam.enum";
 import { useSelectedRoleStore } from "@/stores/selectedRole";
 import { useTeammateStore } from "@/stores/teammateStore";
@@ -21,7 +20,6 @@ import { useUserStore } from "@/stores/userStore";
 const route = useRoute();
 const invitationRole = route.params.role as INVITEDROLE;
 
-const teamStore = useTeamStore();
 const selectedRoleStore = useSelectedRoleStore();
 const teammateStore = useTeammateStore();
 const captainStore = useCaptainStore();
@@ -54,7 +52,7 @@ onBeforeMount(async () => {
 
 const onUserInvitation = (invitedUser: UserWithIdType) => {
   if (invitationRole === INVITEDROLE.teammate) {
-    teamStore.addUserToTeam(invitedUser.id);
+    teammateStore.addTeammateToTeam(invitedUser.id);
   }
   if (invitationRole === INVITEDROLE.captain) {
     selectedRoleStore.addCaptainToCompany(invitedUser.id);

--- a/yaki_admin/src/stores/authStore.ts
+++ b/yaki_admin/src/stores/authStore.ts
@@ -7,6 +7,7 @@ import { CaptainType } from "@/models/captain.type";
 import { CustomerType } from "@/models/customer.type";
 import { useRoleStore } from "./roleStore";
 import { useSelectedRoleStore } from "./selectedRole";
+import { useModalStore } from "./modalStore";
 
 export const useAuthStore = defineStore("loginStore", {
   state: () => ({
@@ -20,6 +21,8 @@ export const useAuthStore = defineStore("loginStore", {
   }),
   actions: {
     async login(login: string, password: string): Promise<boolean> {
+      const modalStore = useModalStore();
+
       try {
         const userEntity = await loginService.login(login, password);
 
@@ -50,6 +53,10 @@ export const useAuthStore = defineStore("loginStore", {
 
         roleStore.setCaptainsId(userEntity.captainId);
         roleStore.setCustomersIdWhereIgotRights(userEntity.customerId);
+
+        // reset the modal state(visibility, mode, and input values) in case of the user was in the middle of a modal action
+        // and then redirected to the login page for some reason
+        modalStore.resetStates();
 
         router.push(this.returnedUrl);
         return true;

--- a/yaki_admin/src/stores/captainStore.ts
+++ b/yaki_admin/src/stores/captainStore.ts
@@ -2,10 +2,11 @@ import { defineStore } from "pinia";
 import { CaptainType } from "@/models/captain.type";
 import { captainService } from "@/services/captain.service";
 import { UserWithIdType } from "@/models/userWithId.type";
+import { useRoleStore } from "@/stores/roleStore";
 
 interface State {
   captainList: UserWithIdType[];
-  captainToDelete: number;
+  idOfCaptainToDelete: number;
   currentCustomerId: number;
 }
 
@@ -15,19 +16,19 @@ export const useCaptainStore = defineStore("captainStore", {
     captainList: [] as UserWithIdType[],
     // in the customer view, when a captain is selected to maybe be deleted
     // at delete icon press, the captainID will be saved
-    captainToDelete: 0 as number,
+    idOfCaptainToDelete: 0 as number,
     currentCustomerId: 0 as number,
   }),
   getters: {
     getCaptainList: (state: State) => state.captainList,
-    getCaptainToDelete: (state: State) => state.captainToDelete,
+    getCaptainToDelete: (state: State) => state.idOfCaptainToDelete,
     getCurrentCustomerId: (state: State) => state.currentCustomerId,
   },
 
   actions: {
     //get the captainId to delete
     setCaptainToDelete(captainId: number) {
-      this.captainToDelete = captainId;
+      this.idOfCaptainToDelete = captainId;
     },
 
     // get all captains of a customer
@@ -42,10 +43,18 @@ export const useCaptainStore = defineStore("captainStore", {
     },
 
     //delete a captain (disabled)
-    async deleteCaptain(captainId: number): Promise<void> {
-      await captainService.disabledCaptain(captainId);
+    async deleteCaptain(): Promise<void> {
+      await captainService.disabledCaptain(this.idOfCaptainToDelete);
       //refresh captain list
       await this.setAllCaptainsByCustomerId(this.getCurrentCustomerId);
+    },
+
+    /**
+     * Refresh the captain list.
+     */
+    async refreshCaptainList() {
+      const roleStore = useRoleStore();
+      await this.setAllCaptainsByCustomerId(roleStore.getCustomerId);
     },
   },
 });

--- a/yaki_admin/src/ui/components/UserInfoCard.vue
+++ b/yaki_admin/src/ui/components/UserInfoCard.vue
@@ -29,7 +29,7 @@ const props = defineProps({
 });
 
 //define the methods
-const UserToBeRemoved = () => {
+const onRemoveUserPress = () => {
   switch (route.fullPath) {
     case "/dashboard/manage-team":
       teammateStore.setIdOfTeammateToDelete(props.user.teammateId);
@@ -83,7 +83,7 @@ const OpenModalNotImplemented = () => {
         />
 
         <button-icon
-          @click.prevent="UserToBeRemoved"
+          @click.prevent="onRemoveUserPress"
           :icon="deleteIcon"
           alt="supprimer"
         />

--- a/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
+++ b/yaki_admin/src/ui/components/sidebar/SideBarMenuDropDown.vue
@@ -19,7 +19,7 @@ const onClickAddTeam = () => {
 };
 
 const onClickSelectTeam = async (team: TeamType) => {
-  await teamStore.setTeamInfoAndFetchTeammates(team);
+  await teamStore.setTeamSelectedAndFetchTeammates(team);
   router.push({ path: "/dashboard/manage-team" });
 };
 

--- a/yaki_admin/src/ui/views/ModalFrameView.vue
+++ b/yaki_admin/src/ui/views/ModalFrameView.vue
@@ -7,8 +7,14 @@ import { useModalStore } from "@/stores/modalStore";
 import { isATeamType } from "@/models/team.type";
 import { MODALMODE } from "@/constants/modalMode.enum";
 import { TEAMPARAMS } from "@/constants/pathParam.enum";
+import { useTeamStore } from "@/stores/teamStore";
+import { useTeammateStore } from "@/stores/teammateStore";
+import { useCaptainStore } from "@/stores/captainStore";
 
 const modalStore = useModalStore();
+const teamStore = useTeamStore();
+const teammateStore = useTeammateStore();
+const captainStore = useCaptainStore();
 
 const onCancel = () => {
   modalStore.switchModalVisibility(false, null);
@@ -28,7 +34,15 @@ const closeModal = () => {
  *
  */
 const onAccept = async () => {
-  const result = await modalStore.onModalChoiceValidation();
+  const isUserToBeDeleted = modalStore.getMode === MODALMODE.userDelete;
+  const isCaptainToBeDeleted = modalStore.getMode === MODALMODE.captainDelete;
+
+  const result = isUserToBeDeleted
+    ? await teammateStore.deleteTeammateFromTeam()
+    : isCaptainToBeDeleted
+      ? await captainStore.deleteCaptain()
+      : await teamStore.onModalTeamActionAccept();
+
   modalStore.switchModalVisibility(false, null);
 
   if (isATeamType(result)) {

--- a/yaki_admin/src/ui/views/TeamManagementView.vue
+++ b/yaki_admin/src/ui/views/TeamManagementView.vue
@@ -18,7 +18,7 @@ onBeforeMount(async () => {
     teamStore.getTeamList &&
     teamStore.getTeamList.length > 0
   ) {
-    teamStore.setTeamInfoAndFetchTeammates(teamStore.getTeamList[0]);
+    teamStore.setTeamSelectedAndFetchTeammates(teamStore.getTeamList[0]);
   }
 });
 </script>

--- a/yaki_admin/src/utils/images.utils.ts
+++ b/yaki_admin/src/utils/images.utils.ts
@@ -20,6 +20,12 @@ export const setUserAvatarUrl = (user: UserWithIdType) => {
   }
 };
 
+/**
+ * Get the team logo data from the teamstore and return the URL,
+ * Depending of the stored value
+ * @param teamLogo Unit8Array
+ * @returns
+ */
 export const setTeamLogoUrl = (teamLogo: Uint8Array | null) => {
   if (teamLogo) {
     return `data:image/jpeg;base64,${teamLogo}`;


### PR DESCRIPTION
# Description
What are changes related to ?

refactor the stores : modal, team, teammate, captain.

Instead of concentrate all CRUD function in the same store correctly set then in the appropriate stores to prevent a not usefull layer to act on the data.

# Linked Issues
What are the issues fixed by this pull request ?
#1295 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
