### PR TITLE
fix(admin_team_redirection): fix incorrect redirection after team creation while on the deleted team screen resume

### DIFF
--- a/yaki_admin/src/router/router.ts
+++ b/yaki_admin/src/router/router.ts
@@ -37,7 +37,7 @@ const router = createRouter({
             const roleStore = useRoleStore();
 
             if (teamStore.getIsTeamListSetOnLoggin === false) {
-              await teamStore.setTeamListOfACaptain(roleStore.getCaptainsId);
+              await teamStore.setTeamsListByCaptainId(roleStore.getCaptainsId);
             }
             if (teamStore.getTeamList.length === 0) {
               next(`/dashboard/team/${TEAMPARAMS.empty}`);

--- a/yaki_admin/src/stores/teamLogoStore.ts
+++ b/yaki_admin/src/stores/teamLogoStore.ts
@@ -2,6 +2,8 @@ import { MODALMODE } from "@/constants/modalMode.enum";
 import { setTeamLogoUrl } from "@/utils/images.utils";
 import { defineStore } from "pinia";
 import { useTeamStore } from "@/stores/teamStore";
+import { teamLogoService } from "@/services/teamLogo.service";
+import { TeamLogoType } from "@/models/TeamLogo.type";
 
 interface State {
   fileSelected: File | null;
@@ -126,10 +128,18 @@ export const useTeamLogoStore = defineStore("teamLogoStore", {
      */
     async createOrUpdate(): Promise<void> {
       const teamStore = useTeamStore();
-      if (this.fileSelected) {
-        await teamStore.createOrUpdateTeamLogo(this.fileSelected);
-        this.setFileSelected(null);
-      }
+
+      if (!this.fileSelected) return;
+
+      const savedTeamLogo: TeamLogoType = await teamLogoService.createOrUpdateTeamLogo(
+        teamStore.getTeamSelected.id,
+        this.fileSelected,
+      );
+
+      if (savedTeamLogo.teamLogoBlob === null) return;
+      teamStore.teamSelectedLogo = savedTeamLogo;
+
+      this.setFileSelected(null);
     },
 
     /**
@@ -140,7 +150,10 @@ export const useTeamLogoStore = defineStore("teamLogoStore", {
      */
     async delete(): Promise<Promise<void>> {
       const teamStore = useTeamStore();
-      await teamStore.deleteTeamLogo();
+
+      teamLogoService.deleteTeamLogo(teamStore.getTeamSelected.id);
+      teamStore.resetTeamStoreSelectedLogo();
+
       this.setFileSelected(null);
       this.setIsLogoToBeDeleted(false);
     },

--- a/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
+++ b/yaki_admin/src/ui/components/modals/ModalCreateEditTeam.vue
@@ -31,14 +31,23 @@ const modalText = ref({
 });
 
 /**
- * Reset the state of :
+ * Reset on modal accept or cancel.
  * * isMissingTeamNameError (error when user try to submit an empty team name)
  * * isFileSizeTooBig (error when user try to submit a logo that is too heavy)
- * * isLogoToBeDeleted (flag to delete the logo)
+ *
  */
-const resetRef = () => {
+const teamNameAndFileSizeFlagReset = () => {
   if (isMissingTeamNameError.value) isMissingTeamNameError.value = false;
   if (teamLogoStore.isFileSizeTooBig) teamLogoStore.isFileSizeTooBig = false;
+};
+
+/**
+ * On open picker and remove logo press.
+ * Reset the size and delete flag to reset the visual effects on selecting new file.
+ */
+const sizeAndDeleteFlagReset = () => {
+  if (teamLogoStore.getIsFileSizeTooBig) teamLogoStore.setIsFileSizeTooBig(false);
+  if (teamLogoStore.getIsLogoToBeDeleted) teamLogoStore.setIsLogoToBeDeleted(false);
 };
 
 /**
@@ -85,13 +94,12 @@ watch(
 
 /**
  * Open the file picker and reset the file flag.
- * If IsFileSizeTooBig was set to true, reset the flag.
- * If isLogoToBeDeleted is set to true, reset the flag.
+ * reset size and delete logo flags, to reset the visuals effect on selecting new file.
  */
-const openFilePickerAndResetFileFlag = () => {
+const openFilePicker = () => {
   inputFileElement.value!.click();
-  if (teamLogoStore.getIsFileSizeTooBig) teamLogoStore.setIsFileSizeTooBig(false);
-  if (teamLogoStore.getIsLogoToBeDeleted) teamLogoStore.isLogoToBeDeleted = false;
+
+  sizeAndDeleteFlagReset();
 };
 
 /**
@@ -104,7 +112,7 @@ const onAddLogoPress = () => {
   if (teamLogoStore.isLogoToBeDeleted) {
     teamLogoStore.setIsLogoToBeDeleted(false);
   }
-  openFilePickerAndResetFileFlag();
+  openFilePicker();
 };
 
 /**
@@ -117,9 +125,7 @@ const onAddLogoPress = () => {
 const onRemoveLogoPress = () => {
   // allow to toggle the delete flag so visual effect
   if (teamLogoStore.getIsLogoToBeDeleted) {
-    teamLogoStore.setIsLogoToBeDeleted(false);
-    // reset visual effect.
-    teamLogoStore.setIsFileSizeTooBig(false);
+    sizeAndDeleteFlagReset();
     return;
   }
 
@@ -148,7 +154,7 @@ const onModalAccept = async () => {
     return;
   }
   emit("onAccept");
-  resetRef();
+  teamNameAndFileSizeFlagReset();
 };
 
 /**
@@ -156,7 +162,7 @@ const onModalAccept = async () => {
  */
 const onModalCancel = () => {
   emit("onCancel");
-  resetRef();
+  teamNameAndFileSizeFlagReset();
 };
 
 /**

--- a/yaki_admin/src/ui/views/ModalFrameView.vue
+++ b/yaki_admin/src/ui/views/ModalFrameView.vue
@@ -12,6 +12,8 @@ import { useTeammateStore } from "@/stores/teammateStore";
 import { useCaptainStore } from "@/stores/captainStore";
 import { useTeamLogoStore } from "@/stores/teamLogoStore";
 
+import defaultTeamImage from "@/assets/images/teamDefaultImg2.svg";
+
 const modalStore = useModalStore();
 const teamStore = useTeamStore();
 const teammateStore = useTeammateStore();
@@ -67,7 +69,12 @@ const handleTeamLogo = () => {
       teamLogoStore.createOrUpdate();
     }
   }
-  if (modalStore.getMode === MODALMODE.teamDelete) teamLogoStore.delete();
+  const isDefaultOrNoLogo =
+    teamLogoStore.getLogoDisplayed !== "" || teamLogoStore.getLogoDisplayed !== defaultTeamImage;
+
+  if (!isDefaultOrNoLogo && modalStore.getMode === MODALMODE.teamDelete) {
+    teamLogoStore.delete();
+  }
 };
 
 const handleRedirect = (result: any) => {
@@ -89,11 +96,10 @@ const handleRedirect = (result: any) => {
  * At modal accept validation.
  */
 const onAccept = async () => {
-  const result = restActions();
+  const result = await restActions();
+
   handleTeamLogo();
-
   modalStore.switchModalVisibility(false, null);
-
   handleRedirect(result);
 };
 </script>


### PR DESCRIPTION
# Description
What are changes related to ?

fix incorrect redirect from the team deletion screen, when user create a new team.
Refactor the teamlogo method to only set them in the teamLogoStore

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
