### PR TITLE
fix(admin_team): selected team after creation to have value aviable to the logo creation

### DIFF
--- a/yaki_admin/src/stores/teamLogoStore.ts
+++ b/yaki_admin/src/stores/teamLogoStore.ts
@@ -138,7 +138,6 @@ export const useTeamLogoStore = defineStore("teamLogoStore", {
 
       if (savedTeamLogo.teamLogoBlob === null) return;
       teamStore.teamSelectedLogo = savedTeamLogo;
-
       this.setFileSelected(null);
     },
 

--- a/yaki_admin/src/stores/teamStore.ts
+++ b/yaki_admin/src/stores/teamStore.ts
@@ -121,7 +121,10 @@ export const useTeamStore = defineStore("teamStore", {
       switch (modalStore.getMode) {
         case MODALMODE.teamCreate: {
           result = await this.createTeam();
+          await this.sharedPostCrudOperations(result);
+
           await teamLogoStore.createOrUpdate();
+
           this.resetTeammatesList();
           this.resetModalInputsValues();
           break;
@@ -129,15 +132,16 @@ export const useTeamStore = defineStore("teamStore", {
         case MODALMODE.teamEdit: {
           result = await this.updateTeam();
           this.resetModalInputsValues();
+          await this.sharedPostCrudOperations(result);
           break;
         }
         case MODALMODE.teamDelete: {
           result = await this.deleteTeam();
           this.resetTeammatesList();
+          await this.sharedPostCrudOperations(result);
           break;
         }
       }
-      await this.sharedPostCrudOperations(result);
 
       return result;
     },


### PR DESCRIPTION
# Description
What are changes related to ?

logo creation on team creation need to have created team date to properly save the logo

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
