### PR TITLE
fix(mobile_registration): set correct error message when email is already used. review snackbar message colors for readability

### DIFF
--- a/yaki_mobile/assets/translations/en.json
+++ b/yaki_mobile/assets/translations/en.json
@@ -54,7 +54,6 @@
   "registrationInputNameError2": "This field must only contain letters",
   "registrationInputEmailLabel": "Email :",
   "registrationInputEmailError": "Incorrect email format",
-  "registrationAlreadyUsedEmail": "This email is already used",
   "registrationInputPasswordLabel": "Password :",
   "registrationInputPasswordError1": "Please create a password",
   "registrationInputPasswordError2": "Minimum : 10 characters \n- One Upper and lowercase \n- A number \n- A special character",
@@ -64,7 +63,7 @@
   "registrationButton": "register",
   "registrationSnackSuccess": "Account creation sucess. Please check yours emails",
   "registrationSnackError": "Oups, something went wrong, try again later",
-  "registrationSnackEmailError": "eamil already used",
+  "registrationSnackEmailError": "The email address you entered is already associated with an existing account. \n Please sign in or use another email address.",
 
   "registrationSnackValidation": "Confirm",
   "registrationCancelButton": "Cancel",

--- a/yaki_mobile/assets/translations/fr.json
+++ b/yaki_mobile/assets/translations/fr.json
@@ -56,7 +56,6 @@
   "registrationInputNameError2": "Ce champ ne doit contenir que des lettres",
   "registrationInputEmailLabel": "Email :",
   "registrationInputEmailError": "Le format de l'email est incorrect",
-  "registrationAlreadyUsedEmail": "Cet email est déjà utilisé",
   "registrationInputPasswordLabel": "Mot de passe :",
   "registrationInputPasswordError1": "Veuillez renseigner un mot de passe",
   "registrationInputPasswordError2": "- Minimum : 10 caractères : \n - Une majuscule et minuscule \n - Un chiffre \n - Un caractère spécial",
@@ -66,7 +65,7 @@
   "registrationButton": "Créer",
   "registrationSnackSuccess": "Création de compte réussie. Veuillez vérifier vos emails",
   "registrationSnackError": "Erreur lors de l'inscription, Veuillez réessayer",
-  "registrationSnackEmailError": "Cet email est déjà utilisé",
+  "registrationSnackEmailError": "L'adresse e-mail que vous avez saisie est déjà associée à un compte existant. \n Veuillez vous connecter ou utiliser une autre adresse.",
 
   "registrationSnackValidation": "Valider",
   "registrationCancelButton": "Annuler",

--- a/yaki_mobile/lib/presentation/features/registration/registration.dart
+++ b/yaki_mobile/lib/presentation/features/registration/registration.dart
@@ -63,7 +63,7 @@ class _RegistrationState extends ConsumerState<Registration> {
         showSnackBar(
           content: tr("registrationSnackSuccess"),
           textStyle: registrationSnackTextStyle(
-            textColor: const Color.fromARGB(255, 82, 251, 45),
+            textColor: const Color.fromARGB(255, 99, 224, 71),
           ),
           actionLabel: tr('registrationSnackValidation'),
           barAction: () {},
@@ -74,18 +74,18 @@ class _RegistrationState extends ConsumerState<Registration> {
         showSnackBar(
           content: tr("registrationSnackError"),
           textStyle: registrationSnackTextStyle(
-            textColor: const Color.fromARGB(255, 245, 33, 33),
+            textColor: const Color.fromARGB(255, 230, 113, 113),
           ),
           actionLabel: tr('registrationCancelButton'),
           barAction: () {},
         );
       } else if (registrationResult == "registrationInputEmailError") {
         showSnackBar(
-          content: tr('registrationCancelButton'),
+          content: tr('registrationSnackEmailError'),
           textStyle: registrationSnackTextStyle(
-            textColor: const Color.fromARGB(255, 245, 33, 33),
+            textColor: const Color.fromARGB(255, 230, 113, 113),
           ),
-          actionLabel: "Ok",
+          actionLabel: tr('registrationCancelButton'),
           barAction: () {},
         );
       }


### PR DESCRIPTION
# Description
What are changes related to ?

Change the error message at registration if the email is already used for another account.
Review error message colors for readability

# Linked Issues
What are the issues fixed by this pull request ?
#1286 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
