### PR TITLE
fix(pic_upload): change upload picture button color button to be more visible

### DIFF
--- a/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
+++ b/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
@@ -157,7 +157,7 @@ class AvatarModalState extends ConsumerState<AvatarModal> {
                     ),
                   const SizedBox(height: 20),
                   if (_imageFile != null)
-                    Button.secondary(
+                    Button(
                       text: tr('upload').toUpperCase(),
                       onPressed: () => uploadImage(
                         'userPicture',


### PR DESCRIPTION
# Description
What are changes related to ?

In user profil, change the upload picture button color to be a better call to action button.

# Linked Issues
What are the issues fixed by this pull request ?
#1303

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="362" alt="Capture d’écran 2024-02-13 à 10 32 11" src="https://github.com/XPEHO/YAKI/assets/95299697/2ca9bd3e-55ab-457f-8403-b124b510934e">


# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
