### PR TITLE
fix(pic_preview): reset the preview when selecting a new picture

### DIFF
--- a/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
+++ b/yaki_mobile/lib/presentation/features/profile/view/avatar_modal.dart
@@ -27,6 +27,10 @@ class AvatarModalState extends ConsumerState<AvatarModal> {
     final LoggedUser? user = ref.watch(loginRepositoryProvider).loggedUser;
 
     Future<void> pickImage(ImageSource source) async {
+      setState(() {
+        _imageFile = null;
+      });
+
       final pickedFile = await ImagePicker().pickImage(
         source: source,
         maxHeight: 640,


### PR DESCRIPTION
# Description
What are changes related to ?

A preview image is display in the selection avatar modal when a picture is picked, either from camera or gallery.
This image wasn't reseting when a new image was selected

# Linked Issues
What are the issues fixed by this pull request ?
#1307 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
