### PR TITLE
chore(node20): set not version to 20, only leave flutter stable setting in the CI

### DIFF
--- a/.github/workflows/docker push release.yaml
+++ b/.github/workflows/docker push release.yaml
@@ -28,7 +28,6 @@ jobs:
           rm -rf /opt/hostedtoolcache/flutter
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.19.2"
           channel: "stable"
       - name: Install lcov
         run: |
@@ -72,6 +71,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Build and publish Yaki frontend admin Docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username phanatic --password-stdin

--- a/.github/workflows/docker push.yaml
+++ b/.github/workflows/docker push.yaml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.19.2"
           channel: "stable"
       - name: Install lcov
         run: |
@@ -68,6 +67,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Build and publish Yaki frontend admin Docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username phanatic --password-stdin

--- a/.github/workflows/test_&_build.yaml
+++ b/.github/workflows/test_&_build.yaml
@@ -14,7 +14,6 @@ jobs:
           distribution: "temurin"
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.19.2"
           channel: "stable"
       - name: Install lcov
         run: |
@@ -36,7 +35,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.19.2"
           channel: "stable"
       - name: Build web
         run: |


### PR DESCRIPTION
# Description
What are changes related to ?

fix node version to 20 when using action/setup-node@v4
remove flutter version, only leave channel: stable as CI parameter

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [ ] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
