### PR TITLE
fix(language_button): the button correctly reflect the selected language and saved language

### DIFF
--- a/yaki_admin/src/ui/components/LanguageSwitch.vue
+++ b/yaki_admin/src/ui/components/LanguageSwitch.vue
@@ -1,12 +1,22 @@
 <script setup>
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 const { locale } = useI18n();
 
-const languageSelected = ref("fr");
+const languageSelected = ref("");
 
-// Load the saved language from local storage or default to 'en'
-locale.value = localStorage.getItem("language") || "fr";
+onMounted(() => {
+  let storedLanguage = localStorage.getItem("language");
+  const browserLanguage = navigator.language || navigator.languages[0];
+
+  if (!storedLanguage) {
+    // Save the selected language to local storage
+    storedLanguage = browserLanguage.includes("fr") ? "fr" : "en";
+  }
+
+  locale.value = storedLanguage;
+  languageSelected.value = storedLanguage;
+});
 
 const switchLanguage = () => {
   locale.value = locale.value === "en" ? "fr" : "en";


### PR DESCRIPTION
# Description
What are changes related to ?

Fix the button that was not correctly reflecting the language saved in the localstorage 

Add a browser language detection, if the language is different than french it will set the language to En

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
