### PR TITLE
reactor(latest_declaration): the latest declaration flag in the database will be per day

### DIFF
--- a/yaki_backend/src/features/declaration/declaration.repository.ts
+++ b/yaki_backend/src/features/declaration/declaration.repository.ts
@@ -191,7 +191,9 @@ export class DeclarationRepository {
       await client.query(
         `UPDATE public.declaration d
          SET declaration_is_latest = false
-         WHERE declaration_is_latest = true AND declaration_user_id = $1
+         WHERE declaration_is_latest = true 
+         AND declaration_user_id = $1
+         AND DATE(declaration_date) = (CURRENT_DATE AT TIME ZONE 'UTC')
          RETURNING *`,
         [userId]
       );


### PR DESCRIPTION
# Description
What are changes related to ?

update the is latest declaration flag change logic to only act for the current day and not every latest declarations.
This way eeach day will have a "is latest declaration"

# Linked Issues
What are the issues fixed by this pull request ?
#1404 

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
