### PR TITLE
feat(admin_tutoriels): tutoriel creation in admin front end.

### DIFF
--- a/yaki_admin/src/assets/style/_style.scss
+++ b/yaki_admin/src/assets/style/_style.scss
@@ -145,3 +145,37 @@ $loader-fade-duration: 0.5s;
     opacity: 0;
   }
 }
+
+// Tutoriels ==============================================
+
+.margin-top-3 {
+  margin-top: 3rem;
+}
+
+.margin-top-2 {
+  margin-top: 2rem;
+}
+
+.margin-top-1 {
+  margin-top: 1rem;
+}
+
+.p-tutoriel-common {
+  font-family: $font-sf-compact;
+  color: #7d818c;
+  text-align: center;
+}
+.p-tutoriel-main {
+  font-size: 1.4rem;
+  font-weight: 800;
+  line-height: 120%;
+}
+.p-tutoriel-secondary {
+  font-size: 1.2rem;
+  font-weight: 500;
+
+  span {
+    font-size: 1.3rem;
+    font-weight: 800;
+  }
+}

--- a/yaki_admin/src/assets/translations/en.json
+++ b/yaki_admin/src/assets/translations/en.json
@@ -47,6 +47,16 @@
     "createTeam": "create team",
     "option": "option"
   },
+  "tutorials": {
+    "captainTitle": "Welcome to the captain management section",
+    "captainContent1": "There is still no captain in your company.",
+    "captainContent2": "To change this, you can invite a co-worker to take on this role using the",
+    "teamTitle": "Welcome to your new team",
+    "teamContent1": "There are still no members in your team.",
+    "teamContent2": "To change this, you can invite teammates using the",
+    "invit": "Invitation",
+    "button": "button"
+  },
   "header": {
     "teammateInvitation": "Teammate invitation : ",
     "teammateAddedTo": "User will be added to :",

--- a/yaki_admin/src/assets/translations/fr.json
+++ b/yaki_admin/src/assets/translations/fr.json
@@ -47,6 +47,16 @@
     "createTeam": "créer une équipe",
     "option": "option"
   },
+  "tutorials": {
+    "captainTitle": "Bienvenue dans la section gestion des capitaines.",
+    "captainContent1": "Il n'y a toujours pas de capitaine dans votre entreprise.",
+    "captainContent2": "Pour changer cela, vous pouvez inviter un collègue à prendre ce rôle en utilisant",
+    "teamTitle": "Bienvenu sur votre nouvelle équipe",
+    "teamContent1": "Elle ne contient pour l'instant pas de membres.",
+    "teamContent2": "Pour changer cela, vous pouvez inviter des coéquipiers en utilisant",
+    "invit": "Inviter",
+    "button": "Le button :"
+  },
   "header": {
     "teammateInvitation": "Invitation d'un coéquipier : ",
     "teammateAddedTo": "L'utilisateur sera ajouté à :",

--- a/yaki_admin/src/ui/components/LanguageSwitch.vue
+++ b/yaki_admin/src/ui/components/LanguageSwitch.vue
@@ -31,18 +31,18 @@ const switchLanguage = () => {
     @click.prevent="switchLanguage"
     :class="['language_switch_container', languageSelected === 'en' ? 'toggle-position' : '']"
   >
-    <p>Fr</p>
-    <p>En</p>
+    <p :class="languageSelected === 'fr' ? 'p_selected' : 'p_not_selected'">Fr</p>
+    <p :class="languageSelected === 'fr' ? 'p_not_selected' : 'p_selected'">En</p>
   </section>
 </template>
 
-<style lang="scss">
+<style scoped lang="scss">
 .language_switch_container {
   isolation: isolate;
   display: flex;
   justify-content: space-between;
   width: 60px;
-  height: 90px;
+  height: 30px;
   cursor: pointer;
 
   position: relative;
@@ -53,16 +53,26 @@ const switchLanguage = () => {
     font-weight: 700;
     padding: 0 0.5rem;
     z-index: 1;
+    user-select: none;
+    transition: all 0.25s ease-in-out;
   }
+}
+
+.p_selected {
+  color: $font-color-main-text;
+}
+
+.p_not_selected {
+  color: $font-color-sub-text;
 }
 
 .language_switch_container::after {
   content: "";
   position: absolute;
   width: 55%;
-  height: 40%;
+  height: 100%;
   background-color: $background-color-theme-secondary;
-  transition: all 0.2s ease-in-out;
+  transition: all 0.25s ease-in-out;
   transform: translateY(-10%);
   border-radius: 8px;
 }

--- a/yaki_admin/src/ui/components/LoginForm.vue
+++ b/yaki_admin/src/ui/components/LoginForm.vue
@@ -139,6 +139,7 @@ const openYakiWeb = () => {
   letter-spacing: 0.4px;
   padding-inline-start: 1.2rem;
 
+  min-height: 100px;
   span {
     font-weight: 600;
     color: $green-xpeho-color;

--- a/yaki_admin/src/ui/components/tutoriels/DeletedTeamTutoriel.vue
+++ b/yaki_admin/src/ui/components/tutoriels/DeletedTeamTutoriel.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+const { locale } = useI18n();
+
+defineProps({
+  teamName: {
+    type: String,
+    required: true,
+  },
+  teamLogo: {
+    type: String,
+    required: true,
+  },
+  captainTeamListLenght: {
+    type: Number,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <div class="tutoriel-deleted-team__container">
+    <p class="p-tutoriel-main p-tutoriel-common">
+      {{ $t("teamStatus.deletedTeamName") }}{{ teamName }}
+    </p>
+    <figure class="deleted-team__figure">
+      <img
+        :src="teamLogo"
+        alt=""
+      />
+    </figure>
+    <p class="p-tutoriel-secondary p-tutoriel-common margin-top-2">
+      {{ $t("teamStatus.deletedTeamConfirmation") }}
+    </p>
+
+    <div
+      v-if="captainTeamListLenght === 0"
+      class="margin-top-3"
+    >
+      <p class="p-tutoriel-secondary p-tutoriel-common">{{ $t("teamStatus.noTeamLeft") }}</p>
+      <p
+        v-if="locale == 'en'"
+        class="p-tutoriel-secondary p-tutoriel-common margin-top-1"
+      >
+        {{ $t("teamStatus.howToCreateATeam1") }}
+        <span>{{ $t("teamStatus.createTeam") }}</span>
+        {{ $t("teamStatus.option") }}
+      </p>
+      <p
+        v-else
+        class="p-tutoriel-secondary p-tutoriel-common margin-top-1"
+      >
+        {{ $t("teamStatus.howToCreateATeam1") }}
+        <span>{{ $t("teamStatus.createTeam") }}</span>
+      </p>
+    </div>
+  </div>
+</template>

--- a/yaki_admin/src/ui/components/tutoriels/InviteCaptainTutorial.vue
+++ b/yaki_admin/src/ui/components/tutoriels/InviteCaptainTutorial.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+const { locale } = useI18n();
+</script>
+
+<template>
+  <section>
+    <p class="p-tutoriel-common p-tutoriel-main">{{ $t("tutorials.captainTitle") }}</p>
+    <p class="p-tutoriel-common p-tutoriel-secondary margin-top-3">
+      {{ $t("tutorials.captainContent1") }}
+    </p>
+    <p class="p-tutoriel-common p-tutoriel-secondary">
+      {{ $t("tutorials.captainContent2") }}
+    </p>
+
+    <p
+      v-if="locale == 'en'"
+      class="p-tutoriel-common p-tutoriel-secondary margin-top-2"
+    >
+      <span class="color-primary">{{ $t("tutorials.invit") }}</span>
+      {{ $t("tutorials.button") }}
+    </p>
+
+    <p
+      v-else
+      class="p-tutoriel-common p-tutoriel-secondary margin-top-2"
+    >
+      {{ $t("tutorials.button") }}
+      <span class="color-primary">{{ $t("tutorials.invit") }}</span>
+    </p>
+  </section>
+</template>
+
+<style scoped lang="scss">
+section {
+  padding-block-start: 12rem;
+
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p:nth-of-type(3) {
+    margin-top: 0.3rem;
+  }
+
+  .color-primary {
+    font-size: 1.4rem;
+    color: $background-color-theme-secondary;
+    margin-inline: 0.2rem;
+  }
+}
+</style>

--- a/yaki_admin/src/ui/components/tutoriels/InviteMemberTutorial.vue
+++ b/yaki_admin/src/ui/components/tutoriels/InviteMemberTutorial.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+const { locale } = useI18n();
+</script>
+
+<template>
+  <section>
+    <p class="p-tutoriel-common p-tutoriel-main">{{ $t("tutorials.teamTitle") }}</p>
+    <p class="p-tutoriel-common p-tutoriel-secondary margin-top-3">
+      {{ $t("tutorials.teamContent1") }}
+    </p>
+    <p class="p-tutoriel-common p-tutoriel-secondary">
+      {{ $t("tutorials.teamContent2") }}
+    </p>
+
+    <p
+      v-if="locale == 'en'"
+      class="p-tutoriel-common p-tutoriel-secondary margin-top-2"
+    >
+      <span class="color-primary">{{ $t("tutorials.invit") }}</span>
+      {{ $t("tutorials.button") }}
+    </p>
+
+    <p
+      v-else
+      class="p-tutoriel-common p-tutoriel-secondary margin-top-2"
+    >
+      {{ $t("tutorials.button") }}
+      <span class="color-primary">{{ $t("tutorials.invit") }}</span>
+    </p>
+  </section>
+</template>
+
+<style scoped lang="scss">
+section {
+  padding-block-start: 12rem;
+
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p:nth-of-type(3) {
+    margin-top: 0.3rem;
+  }
+
+  .color-primary {
+    font-size: 1.4rem;
+    color: $background-color-theme-secondary;
+    margin-inline: 0.2rem;
+  }
+}
+</style>

--- a/yaki_admin/src/ui/components/tutoriels/NoTeamTutoriel.vue
+++ b/yaki_admin/src/ui/components/tutoriels/NoTeamTutoriel.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import tutorial from "@/assets/images/tuto_team_creation.png";
+</script>
+
+<template>
+  <div class="tutoriel-deleted-team__container">
+    <p class="p-tutoriel-main p-tutoriel-common">{{ $t("teamStatus.noTeam") }}</p>
+    <p class="p-tutoriel-secondary p-tutoriel-common margin-top-3">
+      {{ $t("teamStatus.howToCreateATeam2") }} <span>{{ $t("teamStatus.createTeam") }}</span>
+    </p>
+    <figure class="tutorial_size">
+      <img
+        :src="tutorial"
+        alt=""
+      />
+    </figure>
+  </div>
+</template>
+
+<style lang="scss">
+.tutorial_size {
+  padding-block-start: 1rem;
+  max-width: 20rem;
+  border-radius: 16px;
+
+  img {
+    width: 100%;
+    object-fit: cover;
+    border-radius: 16px;
+  }
+}
+</style>

--- a/yaki_admin/src/ui/views/CaptainsManagementView.vue
+++ b/yaki_admin/src/ui/views/CaptainsManagementView.vue
@@ -2,6 +2,7 @@
 import { onBeforeMount } from "vue";
 
 import PageContentLayout from "@/ui/layouts/PageContentLayout.vue";
+import InviteCaptainTutorial from "@/ui/components/tutoriels/InviteCaptainTutorial.vue";
 import { useCaptainStore } from "@/stores/captainStore";
 import { useSelectedRoleStore } from "@/stores/selectedRole";
 import { INVITEDROLE } from "@/constants/pathParam.enum";
@@ -24,9 +25,11 @@ onBeforeMount(async () => {
     </template>
     <template #content>
       <user-list
+        v-if="captainStore.getCaptainList.length > 0"
         :userList="captainStore.getCaptainList"
         :isUsingTeamDescription="false"
       />
+      <invite-captain-tutorial v-else />
     </template>
   </page-content-layout>
 </template>

--- a/yaki_admin/src/ui/views/TeamManagementView.vue
+++ b/yaki_admin/src/ui/views/TeamManagementView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import PageContentHeader from "@/ui/components/PageContentHeader.vue";
 import PageContentLayout from "@/ui/layouts/PageContentLayout.vue";
+import InviteMemberTutorial from "@/ui/components/tutoriels/InviteMemberTutorial.vue";
 import { useTeammateStore } from "@/stores/teammateStore";
 import UserList from "@/ui/components/UserList.vue";
 import { INVITEDROLE } from "@/constants/pathParam.enum";
@@ -33,9 +34,12 @@ onBeforeMount(async () => {
     </template>
     <template #content>
       <user-list
+        v-if="teammateStore.teammates.length > 0"
         :userList="teammateStore.teammates"
         :isUsingTeamDescription="true"
       />
+
+      <invite-member-tutorial v-else />
     </template>
   </page-content-layout>
 </template>

--- a/yaki_admin/src/ui/views/TeamStatusNotification.vue
+++ b/yaki_admin/src/ui/views/TeamStatusNotification.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import Tutorial from "@/assets/images/tuto_team_creation.png";
 import avatar from "@/assets/images/avatarLetters.png";
+
+import DeletedTeamTutoriel from "@/ui/components/tutoriels/DeletedTeamTutoriel.vue";
+import NoTeamTutoriel from "@/ui/components/tutoriels/NoTeamTutoriel.vue";
 import { useTeamStore } from "@/stores/teamStore";
 import { useRoute } from "vue-router";
 
@@ -8,84 +10,24 @@ const teamStore = useTeamStore();
 
 const route = useRoute();
 const teamParamState = route.params.state;
-
-import { useI18n } from "vue-i18n";
-
-const { locale } = useI18n();
 </script>
 
 <template>
   <section class="no-team__container">
-    <div
+    <deleted-team-tutoriel
       v-if="teamParamState === 'deleted'"
-      class="no-team-in-list"
-    >
-      <p class="p_main p_common">
-        {{ $t("teamStatus.deletedTeamName") }}{{ teamStore.getTeamDeleted.teamName }}
-      </p>
-      <figure class="deleted_team__figure">
-        <img
-          :src="avatar"
-          alt=""
-        />
-      </figure>
-      <p class="p_secondary p_common margin-top-2">
-        {{ $t("teamStatus.deletedTeamConfirmation") }}
-      </p>
-
-      <div
-        v-if="teamStore.getTeamListByCaptain.length === 0"
-        class="margin-top-3"
-      >
-        <p class="p_secondary p_common">{{ $t("teamStatus.noTeamLeft") }}</p>
-        <p
-          v-if="locale == 'en'"
-          class="p_secondary p_common margin-top-1"
-        >
-          {{ $t("teamStatus.howToCreateATeam1") }}
-          <span>{{ $t("teamStatus.createTeam") }}</span>
-          {{ $t("teamStatus.option") }}
-        </p>
-        <p
-          v-else
-          class="p_secondary p_common margin-top-1"
-        >
-          {{ $t("teamStatus.howToCreateATeam1") }}
-          <span>{{ $t("teamStatus.createTeam") }}</span>
-        </p>
-      </div>
-    </div>
-
-    <div
+      :teamName="teamStore.getTeamDeleted.teamName"
+      :teamLogo="avatar"
+      :captainTeamListLenght="teamStore.getTeamListByCaptain.length"
+    />
+    <no-team-tutoriel
       v-else
-      class="no-team-in-list"
-    >
-      <p class="p_main p_common">{{ $t("teamStatus.noTeam") }}</p>
-      <p class="p_secondary p_common margin-top-3">
-        {{ $t("teamStatus.howToCreateATeam2") }} <span>{{ $t("teamStatus.createTeam") }}</span>
-      </p>
-      <figure class="no_team__figure">
-        <img
-          :src="Tutorial"
-          alt=""
-        />
-      </figure>
-    </div>
+      :teamLogo="avatar"
+    />
   </section>
 </template>
 
-<style scoped lang="scss">
-.margin-top-3 {
-  margin-top: 3rem;
-}
-
-.margin-top-2 {
-  margin-top: 2rem;
-}
-
-.margin-top-1 {
-  margin-top: 1rem;
-}
+<style lang="scss">
 .no-team__container {
   background-color: #ecf0f5;
 
@@ -97,54 +39,21 @@ const { locale } = useI18n();
   align-items: center;
 }
 
-.no-team-in-list {
+.tutoriel-deleted-team__container {
   max-width: 35rem;
 
   display: flex;
   flex-direction: column;
   align-items: center;
 }
-.p_common {
-  color: #7d818c;
-  text-align: center;
-}
-.p_main {
-  font-family: $font-sf-compact;
-  font-size: 1.4rem;
-  font-weight: 800;
-  line-height: 120%;
-}
 
-.p_secondary {
-  font-family: $font-sf-compact;
-  font-size: 1.2rem;
-  font-weight: 500;
-
-  span {
-    font-weight: 700;
-  }
-}
-
-.deleted_team__figure {
+.deleted-team__figure {
   padding-block-start: 1rem;
   max-width: 10rem;
 
   img {
     width: 100%;
     object-fit: cover;
-  }
-}
-
-.no_team__figure {
-  padding-block-start: 2rem;
-  max-width: 20rem;
-  border-radius: 16px;
-
-  img {
-    width: 100%;
-    object-fit: cover;
-    filter: grayscale(20%);
-    border-radius: 16px;
   }
 }
 </style>


### PR DESCRIPTION
# Description
What are changes related to ?

Create tutoriel component to add explanation in the following situation: 
- the newly create team has no teammates, explain how to invite members.
- the captain management screen is empty, explain how to invit a user to take this role.

- set all tutoriel in its own component for clarity.
- Deleted team and no team tutorial are externalised in their own component.

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)
<img width="690" alt="Capture d’écran 2024-05-02 à 15 30 58" src="https://github.com/XPEHO/YAKI/assets/95299697/d9c066b5-1962-4a0b-a003-7ae63059637e">
<img width="698" alt="Capture d’écran 2024-05-02 à 15 31 23" src="https://github.com/XPEHO/YAKI/assets/95299697/60915efb-836e-4146-81c3-4e78bffbe93f">



# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
