### PR TITLE
refactor(function_parameter_name): review function name and parameter rename

### DIFF
--- a/yaki_backend/src/__test__/declaration-service.test.ts
+++ b/yaki_backend/src/__test__/declaration-service.test.ts
@@ -21,15 +21,27 @@ describe("DeclarationService", () => {
     ];
 
     const declarationDtoIn: DeclarationDtoIn[] = [
-      new DeclarationDtoIn(1, 1, new Date(), new Date(), new Date(), StatusDeclaration.REMOTE, 1),
+      new DeclarationDtoIn(
+        1,
+        1,
+        new Date(),
+        new Date(),
+        new Date(),
+        StatusDeclaration.REMOTE,
+        1
+      ),
     ];
 
     /* This test is checking if the declarationService.createDeclaration method returns a new
     declaration. */
     it("should create and return a new declaration", async () => {
-      jest.spyOn(declarationRepository, "createDeclaration").mockResolvedValueOnce(declarationDtoIn);
+      jest
+        .spyOn(declarationRepository, "createDeclaration")
+        .mockResolvedValueOnce(declarationDtoIn);
 
-      const createdDeclaration = await declarationService.createDeclaration(declarationDtoList);
+      const createdDeclaration = await declarationService.createDeclaration(
+        declarationDtoList
+      );
 
       expect(createdDeclaration).toEqual(declarationDtoIn);
     });
@@ -43,7 +55,9 @@ describe("DeclarationService", () => {
         declarationDate: new Date(),
         declarationStatus: "",
       };
-      await expect(declarationService.createDeclaration(declaration)).rejects.toThrow(TypeError);
+      await expect(declarationService.createDeclaration(declaration)).rejects.toThrow(
+        TypeError
+      );
     });
   });
 
@@ -56,9 +70,11 @@ describe("DeclarationService", () => {
     ];
 
     it("should get and return declaration of teammate 1", async () => {
-      jest.spyOn(declarationRepository, "getDeclarationForTeammate").mockResolvedValueOnce(declarationDtoIn);
+      jest
+        .spyOn(declarationRepository, "getLatestDeclarationByUserId")
+        .mockResolvedValueOnce(declarationDtoIn);
 
-      const declarationForTeammates = await declarationService.getDeclarationForTeammate(1);
+      const declarationForTeammates = await declarationService.getLatestDeclarationByUserId(1);
 
       expect(declarationForTeammates).toEqual(declarationDtoIn);
     });
@@ -67,10 +83,14 @@ describe("DeclarationService", () => {
       // Arrange
       const teammateId = 1;
 
-      jest.spyOn(declarationRepository, "getDeclarationForTeammate").mockResolvedValueOnce([]);
+      jest
+        .spyOn(declarationRepository, "getLatestDeclarationByUserId")
+        .mockResolvedValueOnce([]);
 
       // Act and Assert
-      await expect(declarationService.getDeclarationForTeammate(teammateId)).rejects.toThrow(TypeError);
+      await expect(
+        declarationService.getLatestDeclarationByUserId(teammateId)
+      ).rejects.toThrow(TypeError);
     });
   });
 });

--- a/yaki_backend/src/declaration.router.ts
+++ b/yaki_backend/src/declaration.router.ts
@@ -1,9 +1,9 @@
-import express, { Router } from "express";
-import { authService } from "./features/user/authentication.service";
-import { DeclarationController } from "./features/declaration/declaration.controller";
-import { DeclarationRepository } from "./features/declaration/declaration.repository";
-import { DeclarationService } from "./features/declaration/declaration.service";
-import { limiter } from "./middleware/rateLimiter";
+import express, {Router} from "express";
+import {authService} from "./features/user/authentication.service";
+import {DeclarationController} from "./features/declaration/declaration.controller";
+import {DeclarationRepository} from "./features/declaration/declaration.repository";
+import {DeclarationService} from "./features/declaration/declaration.service";
+import {limiter} from "./middleware/rateLimiter";
 
 /* Creating a new router object. */
 const declarationRouter: Router = express.Router();
@@ -36,7 +36,7 @@ declarationRouter.post(
       declarationController.createDeclaration(req, res);
     } catch (error) {
       console.error(error);
-      res.status(500).send({ message: "An error occurred" });
+      res.status(500).send({message: "An error occurred"});
     }
   }
 );
@@ -55,10 +55,10 @@ declarationRouter.get(
     authService.verifyToken(req, res, next),
   async (req, res) => {
     try {
-      declarationController.getDeclarationsForTeammate(req, res);
+      declarationController.getLatestDeclarationByUserID(req, res);
     } catch (error) {
       console.error(error);
-      res.status(500).send({ message: "An error occurred" });
+      res.status(500).send({message: "An error occurred"});
     }
   }
 );

--- a/yaki_backend/src/features/declaration/declaration.controller.ts
+++ b/yaki_backend/src/features/declaration/declaration.controller.ts
@@ -53,10 +53,10 @@ export class DeclarationController {
    * @param {Request} req - Request - the request object
    * @param {Response} res - Response - the response object
    */
-  async getDeclarationsForTeammate(req: Request, res: Response) {
-    const teammateId = Number(req.query.teammateId);
+  async getLatestDeclarationByUserID(req: Request, res: Response) {
+    const userId = Number(req.query.userId);
     try {
-      const declarations = await this.declarationService.getDeclarationForTeammate(teammateId);
+      const declarations = await this.declarationService.getLatestDeclarationByUserId(userId);
       res.status(200).json(declarations);
     } catch (error: any) {
       if (error instanceof TypeError) {

--- a/yaki_backend/src/features/declaration/declaration.repository.ts
+++ b/yaki_backend/src/features/declaration/declaration.repository.ts
@@ -123,10 +123,10 @@ export class DeclarationRepository {
   /**
    * Get the latest declaration for a team mate
    * Select current day declaration, OR declaration ending after the current day (absence situation)
-   * @param {number} teammateId - number
+   * @param {number} userId - number
    * @returns An array of Declaration objects.
    */
-  async getDeclarationForTeammate(teammateId: number): Promise<DeclarationDtoIn[]> {
+  async getLatestDeclarationByUserId(userId: number): Promise<DeclarationDtoIn[]> {
     const client = new Client({
       host: process.env.DB_HOST,
       user: process.env.DB_USER,
@@ -148,7 +148,7 @@ export class DeclarationRepository {
             AND declaration_status = 'absence'
         )
         ORDER BY declaration_date DESC LIMIT 10`,
-        [teammateId]
+        [userId]
       );
 
       const declarationListToFront: DeclarationDtoIn[] = [];

--- a/yaki_backend/src/features/declaration/declaration.service.ts
+++ b/yaki_backend/src/features/declaration/declaration.service.ts
@@ -140,12 +140,12 @@ export class DeclarationService {
 
   /**
    * Get all declarations for a team mate.
-   * @param {number} teammateId - number
+   * @param {number} userId - number
    * @returns DeclarationDtoIn[] | String
    */
-  async getDeclarationForTeammate(teammateId: number): Promise<DeclarationDtoIn[] | string> {
+  async getLatestDeclarationByUserId(userId: number): Promise<DeclarationDtoIn[] | string> {
     const declarationList: DeclarationDtoIn[] =
-      await this.declarationRepository.getDeclarationForTeammate(teammateId);
+      await this.declarationRepository.getLatestDeclarationByUserId(userId);
     if (
       declarationList.length !== 0 ||
       declarationList !== null ||

--- a/yaki_karate/src/test/resources/declaration.feature
+++ b/yaki_karate/src/test/resources/declaration.feature
@@ -137,7 +137,7 @@ Feature: CreationDeclaration
     And header x-access-token = token
     And header user_id = userId
     ##it's a userId but we must put teammateId
-    And param teammateId = 12
+    And param userId = 12
     When method get
     Then status 200
     And match response contains [{ declarationId: '#number', declarationUserId: '#number', declarationDate: '#string', declarationDateStart: '#string', declarationDateEnd: '#string', declarationStatus: 'remote', declarationTeamId: '#number' }]
@@ -154,6 +154,6 @@ Feature: CreationDeclaration
     Given url 'http://localhost:3000/declarations'
     And header x-access-token = token
     And header user_id = userId
-    And param teammateId = 900
+    And param userId = 900
     When method get
     Then status 404

--- a/yaki_mobile/lib/data/repositories/declaration_respository.dart
+++ b/yaki_mobile/lib/data/repositories/declaration_respository.dart
@@ -11,10 +11,11 @@ class DeclarationRepository {
     this._declarationApi,
   );
 
-  Future<bool> getLatestDeclaration(int teamMateId) async {
+  Future<bool> getLatestDeclaration(int userId) async {
     bool isAlreadyHaveDeclaration = false;
     try {
-      final getHttpResponse = await _declarationApi.getDeclaration(teamMateId);
+      final getHttpResponse =
+          await _declarationApi.getLatestDeclarationByUserId(userId);
       final statusCode = getHttpResponse.response.statusCode;
       switch (statusCode) {
         case 200:

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.dart
@@ -9,8 +9,8 @@ abstract class DeclarationApi {
   factory DeclarationApi(Dio dio, {required String baseUrl}) = _DeclarationApi;
 
   @GET('/declarations')
-  Future<HttpResponse> getDeclaration(
-    @Query("teammateId") int id,
+  Future<HttpResponse> getLatestDeclarationByUserId(
+    @Query("userId") int id,
   );
 
   @POST('/declarations')

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
@@ -19,9 +19,9 @@ class _DeclarationApi implements DeclarationApi {
   String? baseUrl;
 
   @override
-  Future<HttpResponse<dynamic>> getDeclaration(int id) async {
+  Future<HttpResponse<dynamic>> getLatestDeclarationByUserId(int id) async {
     final _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{r'teammateId': id};
+    final queryParameters = <String, dynamic>{r'userId': id};
     final _headers = <String, dynamic>{};
     const Map<String, dynamic>? _data = null;
     final _result =

--- a/yaki_mobile/test/unit/data/repositories/declaration_repository_test.dart
+++ b/yaki_mobile/test/unit/data/repositories/declaration_repository_test.dart
@@ -54,7 +54,8 @@ void main() {
         'Successfully GET daily declaration.',
         () async {
           // Stubbing
-          when(mockedDeclarationApi.getDeclaration(teammateId)).thenAnswer(
+          when(mockedDeclarationApi.getLatestDeclarationByUserId(teammateId))
+              .thenAnswer(
             (realInvocation) => Future.value(httpResponse),
           );
           when(httpResponse.response).thenReturn(response);
@@ -71,7 +72,8 @@ void main() {
         'Fail to get the last declaration, or no daily declaration.',
         () async {
           // Stubbing
-          when(mockedDeclarationApi.getDeclaration(teammateId)).thenAnswer(
+          when(mockedDeclarationApi.getLatestDeclarationByUserId(teammateId))
+              .thenAnswer(
             (realInvocation) => Future.value(httpResponse),
           );
           when(httpResponse.response).thenReturn(response);
@@ -88,7 +90,7 @@ void main() {
         'throw exception when get declaration',
         () async {
           // Stubbing
-          when(mockedDeclarationApi.getDeclaration(teammateId))
+          when(mockedDeclarationApi.getLatestDeclarationByUserId(teammateId))
               .thenAnswer((realInvocation) => Future.value(httpResponse));
           when(httpResponse.response).thenReturn(response);
           when(response.statusCode).thenReturn(418);

--- a/yaki_mobile/test/unit/data/repositories/declaration_repository_test.mocks.dart
+++ b/yaki_mobile/test/unit/data/repositories/declaration_repository_test.mocks.dart
@@ -43,17 +43,17 @@ class MockDeclarationApi extends _i1.Mock implements _i3.DeclarationApi {
   }
 
   @override
-  _i4.Future<_i2.HttpResponse<dynamic>> getDeclaration(int? id) =>
+  _i4.Future<_i2.HttpResponse<dynamic>> getLatestDeclarationByUserId(int? id) =>
       (super.noSuchMethod(
         Invocation.method(
-          #getDeclaration,
+          #getLatestDeclarationByUserId,
           [id],
         ),
         returnValue: _i4.Future<_i2.HttpResponse<dynamic>>.value(
             _FakeHttpResponse_0<dynamic>(
           this,
           Invocation.method(
-            #getDeclaration,
+            #getLatestDeclarationByUserId,
             [id],
           ),
         )),


### PR DESCRIPTION
# Description
What are changes related to ?

the get latest declaration of the day, is use to determine where to redirect the user at the connection.
Thoses functions and parameter was incorrectly named as leftover of the first YAKI version.
all function and parameter are correctly renamed to reflect the actual use.
Being to get the latest decalaration by user ID

# Linked Issues
What are the issues fixed by this pull request ?

# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
