### PR TITLE
fix(invitation_page_env): Make unusable the pagination in a certain direction following the current page

### DIFF
--- a/yaki_admin/src/features/invitation/layouts/UserInvitationPageContent.vue
+++ b/yaki_admin/src/features/invitation/layouts/UserInvitationPageContent.vue
@@ -96,6 +96,7 @@ const previewPage = async () => {
     <button
       class="page_count_button"
       @click.prevent="previewPage"
+      :style="userStore.getPageNumber === 0 ? 'pointer-events: none; opacity: 0.2;' : ''"
     >
       <figure>
         <img
@@ -112,6 +113,11 @@ const previewPage = async () => {
     <button
       class="page_count_button"
       @click.prevent="nextPage"
+      :style="
+        userStore.getPageNumber === userStore.getTotalPagesCount - 1
+          ? 'pointer-events: none; opacity: 0.2;'
+          : ''
+      "
     >
       <figure>
         <img


### PR DESCRIPTION
Screenshots of the new behaviour :
![Prev](https://github.com/XPEHO/YAKI/assets/83142634/3457db7e-642e-4a47-8f59-7a678818dc2a)
![Next](https://github.com/XPEHO/YAKI/assets/83142634/8c59ede9-9c29-4e24-aaff-59f79e0bcac4)