### PR TITLE
fix(iOSNotifWhenDeclared): Add endpoint providing user's declared days

### DIFF
--- a/yaki_backend/src/declaration.router.ts
+++ b/yaki_backend/src/declaration.router.ts
@@ -63,5 +63,73 @@ declarationRouter.get(
   }
 );
 
+declarationRouter.get(
+  "/declarations/declaredDays",
+  (req, res, next) => {
+    if (req.query.userId == null) {
+      return res.status(400).send({message: "Missing required query parameter 'userId'"})
+    }
+    if (isNaN(parseInt(req.query.userId as string))) {
+      return res.status(400).send({message: "Invalid userId"})
+    }
+    return authService.verifyToken(req, res, next)
+  },
+  async (req, res) => {
+  /**
+   * @swagger
+   * declarations/declaredDays:
+   *   get:
+   *     summary: Get declared days by user ID
+   *     description: Returns a list of declared days for a specific user.
+   *     tags:
+   *       - Declarations
+   *     parameters:
+   *       - in: query
+   *         name: userId
+   *         description: The ID of the user to retrieve declared days for.
+   *         required: true
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *     responses:
+   *       200:
+   *         description: OK. Returns a list of declared days for the user. Returns [] if the user doesn't exist.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/DeclaredDay'
+   *       400:
+   *         description: Bad Request. Missing required query parameter 'userId'.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   description: The error message.
+   *       500:
+   *         description: Internal Server Error.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   description: The error message.
+   */
+
+    try {
+      declarationController.getDeclaredDaysByUserId(req, res)
+    } catch(error) {
+      console.error(error)
+      res.status(500).send({message: "An error occurred"});
+    }
+  }
+)
+
 /* Exporting the declarationRouter object. */
 export default declarationRouter;

--- a/yaki_backend/src/features/declaration/declaration.controller.ts
+++ b/yaki_backend/src/features/declaration/declaration.controller.ts
@@ -68,4 +68,20 @@ export class DeclarationController {
       }
     }
   }
+
+  async getDeclaredDaysByUserId(req: Request, res: Response) {
+    const userId = Number(req.query.userId);
+    try {
+      const days = await this.declarationService.getDeclaredDaysByUserId(userId)
+      res.status(200).json(days);
+    } catch (error: any) {
+      if (error instanceof TypeError) {
+        // catch not found errors
+        res.status(404).json({message: error.message});
+      } else {
+        // catch server errors
+        res.status(500).json({message: error.message});
+      }
+    }
+  }
 }

--- a/yaki_backend/src/features/declaration/declaration.service.ts
+++ b/yaki_backend/src/features/declaration/declaration.service.ts
@@ -157,6 +157,10 @@ export class DeclarationService {
     }
   }
 
+  async getDeclaredDaysByUserId(userId: number): Promise<String[] | string> {
+      return await this.declarationRepository.getDeclaredDaysByUserId(userId);
+  } 
+
   /**
    * Function returning either daily declaration or both halfday declaration.
    *

--- a/yaki_mobile/ios/Podfile.lock
+++ b/yaki_mobile/ios/Podfile.lock
@@ -37,12 +37,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
-  integration_test: 13825b8a9334a850581300559b8839134b124670
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
-  url_launcher_ios: 6116280ddcfe98ab8820085d8d76ae7449447586
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/yaki_mobile/ios/Runner/Info.plist
+++ b/yaki_mobile/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -22,15 +24,21 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-	<string>mailto</string>
-	<string>tel</string>
-	<string>http</string>
-	<string>https</string>
+		<string>mailto</string>
+		<string>tel</string>
+		<string>http</string>
+		<string>https</string>
 	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access to your camera to take photos and videos.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access to your photo library to save and share your photos.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -50,13 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to your photo library to save and share your photos.</string>
-	<key>NSCameraUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to your camera to take photos and videos.</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
Add a endpoint listing days for which user {userId} has made a declaration.
It is a prerequisite of #1508 

```
Endpoint: /declarations/declaredDays
Verb: GET
Parameters:
  - userId: Id of the user that made the declarations
Responses:
  - 200: OK. List of declared days for the user. [] if the user doesn't exist.
  - 400: Bad Request. Missing required query parameter 'userId'.
  - 400: Bad Request. Invalid userId
```

# Linked Issues
Closes #1507 

# Tests
How has it been tested ?

- [x] Manually
- [x] Automated tests
- [ ] QA
- [ ] Other
