### PR TITLE
fix(flutterChanelForConditionalNotif): In flutter, retrieve declared days and pass them to the platform channels

### DIFF
--- a/yaki_mobile/ios/Runner/AppDelegate.swift
+++ b/yaki_mobile/ios/Runner/AppDelegate.swift
@@ -26,6 +26,11 @@ import UserNotifications
      If the app doesn't have authorization, it disables the notification.
      */
     override func applicationDidBecomeActive(_ application: UIApplication) {
+        getDeclaredDays {
+            debugPrint("Declared days: \($0)")
+            // Note(Loucas): Handle notification scheduling using the declared days here
+        }
+        
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             if settings.authorizationStatus != .authorized {
                 self.disableNotification();

--- a/yaki_mobile/ios/Runner/Constants.swift
+++ b/yaki_mobile/ios/Runner/Constants.swift
@@ -9,6 +9,7 @@ enum FlutterChannel: String {
     case scheduleNotifications = "scheduleNotifications"
     case getNotificationParams = "getNotificationParams"
     case areNotificationsPermitted = "areNotificationsPermitted"
+    case getDeclaredDays = "getDeclaredDays"
 }
 
 /**

--- a/yaki_mobile/ios/Runner/MethodsChannel.swift
+++ b/yaki_mobile/ios/Runner/MethodsChannel.swift
@@ -11,6 +11,19 @@ extension AppDelegate {
         return FlutterMethodChannel(name: FlutterChannel.name.rawValue, binaryMessenger: controller!.binaryMessenger)
     }
     
+   /**
+    Get the list of days that have been declared by the user.
+    */
+    func getDeclaredDays(completion: @escaping ([String]) -> Void) {
+        let channel = getMethodChannel();
+        
+        channel.invokeMethod(FlutterChannel.getDeclaredDays.rawValue, arguments: nil) { (result: Any?) in
+            if let result = result as? [String] {
+                completion(result)
+            }
+        }
+    }
+    
     /**
      This method is used to retrive the notification parameters values from flutter.
      This using the flutter channels.

--- a/yaki_mobile/lib/data/repositories/declaration_respository.dart
+++ b/yaki_mobile/lib/data/repositories/declaration_respository.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:retrofit/retrofit.dart';
 import 'package:yaki/data/models/declaration_model.dart';
 import 'package:yaki/data/models/declaration_model_in.dart';
 import 'package:yaki/data/sources/remote/declaration_api.dart';
@@ -130,5 +131,21 @@ class DeclarationRepository {
       debugPrint("error during creation : $err");
     }
     return statusHalfDay;
+  }
+
+  Future<List<String>> getDeclaredDays(int userId) async {
+    HttpResponse getHttpResponse;
+    try {
+      getHttpResponse = await _declarationApi.getDeclaredDaysByUserId(userId);
+    } catch (err) {
+      debugPrint('Error during http request: $err');
+      return [];
+    }
+    final statusCode = getHttpResponse.response.statusCode;
+    if (statusCode != 200) {
+      debugPrint('Error:  $statusCode\n${getHttpResponse.data}');
+      return [];
+    }
+    return List<String>.from(getHttpResponse.data);
   }
 }

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.dart
@@ -18,4 +18,9 @@ abstract class DeclarationApi {
     @Body() List<DeclarationModel> declaration,
     @Query("mode") String mode,
   );
+
+  @GET('/declarations/declaredDays')
+  Future<HttpResponse> getDeclaredDaysByUserId(
+    @Query("userId") int id,
+  );
 }

--- a/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
+++ b/yaki_mobile/lib/data/sources/remote/declaration_api.g.dart
@@ -77,6 +77,34 @@ class _DeclarationApi implements DeclarationApi {
     return httpResponse;
   }
 
+  @override
+  Future<HttpResponse<dynamic>> getDeclaredDaysByUserId(int id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'userId': id};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result =
+        await _dio.fetch(_setStreamType<HttpResponse<dynamic>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/declarations/declaredDays',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final value = _result.data;
+    final httpResponse = HttpResponse(value, _result);
+    return httpResponse;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/yaki_mobile/test/unit/data/repositories/declaration_repository_test.mocks.dart
+++ b/yaki_mobile/test/unit/data/repositories/declaration_repository_test.mocks.dart
@@ -84,4 +84,21 @@ class MockDeclarationApi extends _i1.Mock implements _i3.DeclarationApi {
           ),
         )),
       ) as _i4.Future<_i2.HttpResponse<dynamic>>);
+
+  @override
+  _i4.Future<_i2.HttpResponse<dynamic>> getDeclaredDaysByUserId(int? id) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getDeclaredDaysByUserId,
+          [id],
+        ),
+        returnValue: _i4.Future<_i2.HttpResponse<dynamic>>.value(
+            _FakeHttpResponse_0<dynamic>(
+          this,
+          Invocation.method(
+            #getDeclaredDaysByUserId,
+            [id],
+          ),
+        )),
+      ) as _i4.Future<_i2.HttpResponse<dynamic>>);
 }


### PR DESCRIPTION
# Description
Retrieve declared days with http request in Flutter and pass them to the respective platform channels (Swift, Kotlin).

# Linked Issues
Closes #1438
 
# Changes
What does it change ?
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots
Put screenshots (if any)

# Tests
How has it been tested ?

- [x] Manually
- [ ] Automated tests
- [ ] QA
- [ ] Other

# Additional information
Precise any other information
